### PR TITLE
Enable iOS file sharing for side-loading data

### DIFF
--- a/Handheld/iOS/Info.plist
+++ b/Handheld/iOS/Info.plist
@@ -25,7 +25,7 @@
 	<key>NOTE</key>
 	<string>Built with ArcGIS Runtime SDK for Qt.</string>
 	<key>UIFileSharingEnabled</key>
-        <string>FALSE</string>
+	<string>YES</string>
 	<key>UIRequiresPersistentWiFi</key>
 	<string>NO</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Vehicle/iOS/Info.plist
+++ b/Vehicle/iOS/Info.plist
@@ -25,7 +25,7 @@
 	<key>NOTE</key>
 	<string>Built with ArcGIS Runtime SDK for Qt.</string>
 	<key>UIFileSharingEnabled</key>
-        <string>FALSE</string>
+	<string>YES</string>
 	<key>UIRequiresPersistentWiFi</key>
 	<string>NO</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Assign to @JamesMBallard 

Enable UI file sharing to be able to side load data from iTunes for these apps since they will require offline data.