### PR TITLE
Include the plugin resources.

### DIFF
--- a/Handheld/arcgisruntime.pri
+++ b/Handheld/arcgisruntime.pri
@@ -31,6 +31,6 @@ priLocation = $$replace(cleanDirPath, '"', "")
 
 ios: {
   !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate PRI file to import toolkit as a plugin")
+    message("Error. Cannot locate PRI file to import Toolkit as a plugin")
   }
 }

--- a/Vehicle/arcgisruntime.pri
+++ b/Vehicle/arcgisruntime.pri
@@ -31,6 +31,6 @@ priLocation = $$replace(cleanDirPath, '"', "")
 
 ios: {
   !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate PRI file to import toolkit as a plugin")
+    message("Error. Cannot locate PRI file to import Toolkit as a plugin")
   }
 }


### PR DESCRIPTION
On iOS, the plugin qml files must be included in the binary directly.

This should fix the iOS builds.