### PR TITLE
Move view-specific connection logic into the apps and out of the tool…

### DIFF
--- a/Handheld/Handheld.cpp
+++ b/Handheld/Handheld.cpp
@@ -44,10 +44,8 @@ void Handheld::componentComplete()
   connect(m_sceneView, &SceneQuickView::spatialReferenceChanged,
           ToolResourceProvider::instance(), &ToolResourceProvider::spatialReferenceChanged);
 
-  connect(m_sceneView, &SceneQuickView::mouseClicked, this, [this](QMouseEvent& event)
-  {
-    emit ToolResourceProvider::instance()->mouseClicked(m_sceneView->screenToBaseSurface(event.x(), event.y()));
-  });
+  connect(m_sceneView, &SceneQuickView::mouseClicked,
+          ToolResourceProvider::instance(), &ToolResourceProvider::onMouseClicked);
 
   // Set scene to scene view
   m_sceneView->setArcGISScene(m_controller->scene());

--- a/Vehicle/Vehicle.cpp
+++ b/Vehicle/Vehicle.cpp
@@ -45,10 +45,8 @@ void Vehicle::componentComplete()
   connect(m_sceneView, &SceneQuickView::spatialReferenceChanged,
           ToolResourceProvider::instance(), &ToolResourceProvider::spatialReferenceChanged);
 
-  connect(m_sceneView, &SceneQuickView::mouseClicked, this, [this](QMouseEvent& event)
-  {
-    emit ToolResourceProvider::instance()->mouseClicked(m_sceneView->screenToBaseSurface(event.x(), event.y()));
-  });
+  connect(m_sceneView, &SceneQuickView::mouseClicked,
+          ToolResourceProvider::instance(), &ToolResourceProvider::onMouseClicked);
 
   // Set scene to scene view
   m_sceneView->setArcGISScene(m_controller->scene());


### PR DESCRIPTION
…kit.

Assigned to @michael-tims

Move the view-specific logic to the Apps. The apps will emit the resource provider signals since they are where the view is created. This keeps any Quick/Widgets dependencies out of the toolkit.

cc: @lsmallwood 
