### PR TITLE
Make it easier for Qt's deployment tool to locate all the imports.

### DIFF
--- a/Shared/qml/Imports.qml
+++ b/Shared/qml/Imports.qml
@@ -1,0 +1,24 @@
+// Copyright 2017 ESRI
+//
+// All rights reserved under the copyright laws of the United States
+// and applicable international laws, treaties, and conventions.
+//
+// You may freely redistribute and use this sample code, with or
+// without modification, provided you include the original copyright
+// notice and use restrictions.
+//
+// See the Sample code usage restrictions document for further information.
+//
+
+import QtQuick 2.6
+import QtQml.Models 2.2
+import QtQuick.Controls 1.4
+import QtQuick.Controls 2.1
+import QtQuick.Controls.Material 2.1
+import QtQuick.Layouts 1.1
+import QtQuick.Window 2.0
+import Esri.ArcGISRuntime.Toolkit.Controls.CppApi 100.2
+
+Item {
+
+}

--- a/Shared/qml/shared_qml.qrc
+++ b/Shared/qml/shared_qml.qrc
@@ -9,5 +9,6 @@
         <file>TableOfContents.qml</file>
         <file>NavigationTool.qml</file>
         <file>TelestrateTool.qml</file>
+        <file>Imports.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Assign to @ldanzinger. Please review.

We've hit some issues with Qt's deployment tool pickup up all the necessary imports for these apps. This should make it easier for the import scanner to locate everything.

