### PR TITLE
Fix casing of slot name

### DIFF
--- a/Handheld/Handheld.cpp
+++ b/Handheld/Handheld.cpp
@@ -60,7 +60,7 @@ void Handheld::componentComplete()
           ToolResourceProvider::instance(), &ToolResourceProvider::onIdentifyGraphicsOverlayCompleted);
 
   connect(m_sceneView, &SceneQuickView::screenToLocationCompleted,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onscreenToLocationCompleted);
+          ToolResourceProvider::instance(), &ToolResourceProvider::onScreenToLocationCompleted);
 
   connect(ToolResourceProvider::instance(), &ToolResourceProvider::setMouseCursorRequested, this, [this](const QCursor& mouseCursor)
   {

--- a/Vehicle/Vehicle.cpp
+++ b/Vehicle/Vehicle.cpp
@@ -61,7 +61,7 @@ void Vehicle::componentComplete()
           ToolResourceProvider::instance(), &ToolResourceProvider::onIdentifyGraphicsOverlayCompleted);
 
   connect(m_sceneView, &SceneQuickView::screenToLocationCompleted,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onscreenToLocationCompleted);
+          ToolResourceProvider::instance(), &ToolResourceProvider::onScreenToLocationCompleted);
 
   connect(ToolResourceProvider::instance(), &ToolResourceProvider::setMouseCursorRequested, this, [this](const QCursor& mouseCursor)
   {


### PR DESCRIPTION
Fixing builds by updating the casing of the SLOT name.