### PR TITLE
Khajra/navigation updates

### DIFF
--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -65,7 +65,7 @@ void NavigationController::updateGeoView()
         if (!m_enabled)
           return;
 
-          m_currentCenter = location;
+        m_currentCenter = location;
 
         if (m_currentMode == Mode::Zoom)
         {
@@ -96,7 +96,7 @@ void NavigationController::zoomIn()
 {
   m_currentMode = Mode::Zoom;
 
-  if (m_cameraMoveDistance < 0.)
+  if (m_cameraMoveDistance < 0.0)
     m_cameraMoveDistance = -m_cameraMoveDistance;
 
   center();
@@ -106,7 +106,7 @@ void NavigationController::zoomOut()
 {
   m_currentMode = Mode::Zoom;
 
-  if (m_cameraMoveDistance > 0.)
+  if (m_cameraMoveDistance > 0.0)
     m_cameraMoveDistance = -m_cameraMoveDistance;
 
   center();

--- a/Shared/NavigationController.h
+++ b/Shared/NavigationController.h
@@ -88,7 +88,7 @@ private:
   Mode m_currentMode;
   bool m_enabled = false;
   bool m_isZoomIn = false;
-  double m_cameraMoveDistance = 1000.;
+  double m_cameraMoveDistance = 1000.0;
 };
 
 


### PR DESCRIPTION
Adding some updates to the zoomin/out in case the center of the screen is not a point on earth.  In that case, just move the camera by a specific distance.  The distance is configurable from qml so that the user can change it.  By default it is 1000.0 meters.