### PR TITLE
macOS deployment version is located in shared pri file

### DIFF
--- a/Handheld/Handheld.pro
+++ b/Handheld/Handheld.pro
@@ -90,7 +90,6 @@ win32 {
 
 macx {
     include (Mac/Mac.pri)
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
 }
 
 ios {

--- a/MessageSimulator/MessageSimulator.pro
+++ b/MessageSimulator/MessageSimulator.pro
@@ -44,5 +44,4 @@ win32 {
 
 macx {
     include (Mac/Mac.pri)
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
 }

--- a/Vehicle/Vehicle.pro
+++ b/Vehicle/Vehicle.pro
@@ -89,7 +89,6 @@ win32 {
 
 macx {
     include (Mac/Mac.pri)
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
 }
 
 ios {


### PR DESCRIPTION
Assign to @JamesMBallard 

`QMAKE_MACOSX_DEPLOYMENT_TARGET` is now located in the shared pri files.  Not needed in all pro files anymore.