### PR TITLE
adding error message signal and error dialog

### DIFF
--- a/Handheld/Handheld.cpp
+++ b/Handheld/Handheld.cpp
@@ -41,10 +41,10 @@ void Handheld::componentComplete()
   m_controller->init(m_sceneView);
 
   // connect to the DSA controller errors
-  connect(m_controller, &DsaController::showErrorMessage, this, [this]
+  connect(m_controller, &DsaController::errorOccurred, this, [this]
           (const QString& message, const QString& additionalMessage)
   {
-    emit showErrorMessage(message, additionalMessage);
+    emit errorOccurred(message, additionalMessage);
   });
 
 

--- a/Handheld/Handheld.h
+++ b/Handheld/Handheld.h
@@ -36,7 +36,7 @@ public:
   void componentComplete() override;
 
 signals:
-  void showErrorMessage(const QString& message, const QString& additionalMessage);
+  void errorOccurred(const QString& message, const QString& additionalMessage);
 
 private:
   Esri::ArcGISRuntime::SceneQuickView*    m_sceneView = nullptr;

--- a/Handheld/qml/main.qml
+++ b/Handheld/qml/main.qml
@@ -446,7 +446,7 @@ Handheld {
         enabled: locationCheckBox.checked
     }
 
-    onShowErrorMessage: {
+    onErrorOccurred: {
         msgDialog.informativeText = message;
         msgDialog.detailedText = additionalMessage;
         msgDialog.open();

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -107,7 +107,7 @@ void DsaController::init(GeoView* geoView)
 void DsaController::onError(const Error& e)
 {
   qDebug() << "Error" << e.message() << e.additionalMessage();
-  emit showErrorMessage(e.message(), e.additionalMessage());
+  emit errorOccurred(e.message(), e.additionalMessage());
 }
 
 void DsaController::onPropertyChanged(const QString &propertyName, const QVariant &propertyValue)

--- a/Shared/DsaController.h
+++ b/Shared/DsaController.h
@@ -49,7 +49,7 @@ private slots:
   void onPropertyChanged(const QString& propertyName, const QVariant& propertyValue);
 
 signals:
-  void showErrorMessage(const QString& message, const QString& additionalMessage);
+  void errorOccurred(const QString& message, const QString& additionalMessage);
 
 private:
   void setupConfig();

--- a/Vehicle/Vehicle.cpp
+++ b/Vehicle/Vehicle.cpp
@@ -42,10 +42,10 @@ void Vehicle::componentComplete()
   m_controller->init(m_sceneView);
 
   // connect to the DSA controller errors
-  connect(m_controller, &DsaController::showErrorMessage, this, [this]
+  connect(m_controller, &DsaController::errorOccurred, this, [this]
           (const QString& message, const QString& additionalMessage)
   {
-    emit showErrorMessage(message, additionalMessage);
+    emit errorOccurred(message, additionalMessage);
   });
 
   // setup the connections from the view to the resource provider

--- a/Vehicle/Vehicle.h
+++ b/Vehicle/Vehicle.h
@@ -36,7 +36,7 @@ public:
   void componentComplete() override;
 
 signals:
-  void showErrorMessage(const QString& message, const QString& additionalMessage);
+  void errorOccurred(const QString& message, const QString& additionalMessage);
 
 private:
   void setCoordinateConversionOptions();

--- a/Vehicle/qml/main.qml
+++ b/Vehicle/qml/main.qml
@@ -447,7 +447,7 @@ Vehicle {
         }
     }
 
-    onShowErrorMessage: {
+    onErrorOccurred: {
         msgDialog.informativeText = message;
         msgDialog.detailedText = additionalMessage;
         msgDialog.open();


### PR DESCRIPTION
@JamesMBallard please review/merge. All API errors are sent to the DSA Controller, so I'm bubbling those out to the Vehicle and Handheld apps so that the QML code can connect to the signal and display the error in a message dialog