### PR TITLE
Dsa Navigation tool:

### DIFF
--- a/Shared/DsaUtility.cpp
+++ b/Shared/DsaUtility.cpp
@@ -20,12 +20,6 @@
 
 using namespace Esri::ArcGISRuntime;
 
-#ifdef Q_OS_WIN
-#define kReferenceDotsPerInch               96
-#else
-#define kReferenceDotsPerInch               72
-#endif
-
 QString DsaUtility::dataPath()
 {
   QDir dataDir;
@@ -49,30 +43,3 @@ Point DsaUtility::montereyCA()
 {
   return Point(-121.9, 36.6, SpatialReference::wgs84());
 }
-
-
-qreal DsaUtility::screenScale()
-{
-  QScreen* screen = QGuiApplication::primaryScreen();
-
-  if (screen)
-  {
-    return screen->devicePixelRatio();
-  }
-  return 1.0; // default to 1.0
-}
-
-qreal DsaUtility::dipsToPixels()
-{
-#ifdef Q_OS_MAC
-  return screenScale();
-#else
-  QScreen* screen = QGuiApplication::primaryScreen();
-  if (screen)
-  {
-    return (screen->logicalDotsPerInch() * screen->devicePixelRatio()) / kReferenceDotsPerInch;
-  }
-  return 1.0; // default to 1.0
-#endif
-}
-

--- a/Shared/DsaUtility.h
+++ b/Shared/DsaUtility.h
@@ -25,10 +25,6 @@ public:
 
   static QString dataPath();
   static Esri::ArcGISRuntime::Point montereyCA();
-
-  // dpi
-  static qreal screenScale();
-  static qreal dipsToPixels();
 };
 
 #endif // UTILITY_H

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -303,8 +303,8 @@ void NavigationController::center()
     return;
 
   m_enabled = true;
-  const double factor = DsaUtility::dipsToPixels();
-  m_sceneView->screenToLocation(static_cast<int>(m_sceneView->sceneWidth() / factor) * 0.5, static_cast<int>(m_sceneView->sceneHeight() / factor) * 0.5);
+
+  m_sceneView->screenToLocation(m_sceneView->widthInPixels() * 0.5, m_sceneView->heightInPixels() * 0.5);
 }
 
 double NavigationController::currentCameraDistance(const Camera &currentCamera)


### PR DESCRIPTION
- Use the new widthInPixels and heighInPixels method
- remove dpi methods from DsaUtility

@michael-tims please review the fix for the navigation tool (using the new api methods)