### PR TITLE
Dsa Basemap: fix duplicates

### DIFF
--- a/Shared/BasemapPickerController.cpp
+++ b/Shared/BasemapPickerController.cpp
@@ -62,6 +62,8 @@ void BasemapPickerController::setDefaultBasemap(const QString& defaultBasemap)
 
 void BasemapPickerController::onBasemapDataPathChanged()
 {
+  m_tileCacheModel->clear();
+
   QDir basemapsDir(m_basemapDataPath);
 
   basemapsDir.setFilter(QDir::Files | QDir::Hidden | QDir::NoSymLinks);

--- a/Shared/TileCacheListModel.cpp
+++ b/Shared/TileCacheListModel.cpp
@@ -142,3 +142,11 @@ QString TileCacheListModel::tileCacheNameAt(int row) const
 
   return QFileInfo(m_tileCacheData.at(row)->path()).completeBaseName();
 }
+
+void TileCacheListModel::clear()
+{
+  beginResetModel();
+  m_thumbnailUrls.clear();
+  m_tileCacheData.clear();
+  endResetModel();
+}

--- a/Shared/TileCacheListModel.h
+++ b/Shared/TileCacheListModel.h
@@ -44,6 +44,7 @@ public:
   bool append(const QString& pathToTileCache);
   Esri::ArcGISRuntime::TileCache* tileCacheAt(int row) const;
   QString tileCacheNameAt(int row) const;
+  void clear();
 
   // QAbstractItemModel interface
   int rowCount(const QModelIndex& parent) const override;


### PR DESCRIPTION
- added a clear method to TileCacheListModel
- clear the model when the basemaps data path changes

@ldanzinger please review the fix for the duplicate basemaps