### PR TITLE
setting identify controller active

### DIFF
--- a/Shared/qml/MapToolRow.qml
+++ b/Shared/qml/MapToolRow.qml
@@ -161,6 +161,8 @@ Row {
             } else
                 mapToolRow.state = toolName;
 
+            identifyController.active = selected;
+
             if (identifyResults.visible) {
                 identifyResults.visible = false;
                 mapToolRow.state = "clear";


### PR DESCRIPTION
@michael-tims please review/merge. Somewhere in the mix of UI changes, the active state was no longer being set, so Identify never happened 