### PR TITLE
Connect LocationController locationChanged to the Toolkit

### DIFF
--- a/Shared/LocationController.cpp
+++ b/Shared/LocationController.cpp
@@ -41,6 +41,7 @@ LocationController::LocationController(QObject* parent) :
 {
   Toolkit::ToolManager::instance().addTool(this);
 
+  connect(this, &LocationController::locationChanged, Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::onLocationChanged);
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::geoViewChanged, this, &LocationController::updateGeoView);
 
   updateGeoView();


### PR DESCRIPTION
@ldanzinger please review and merge.

Connecting the LocationController's `locationChanged` signal to the ToolResourceProvider

When the LocationController is `enabled` (which is default) all tools will now be able to get location updates from the ToolResourceProvider singleton