### PR TITLE
return if no coordinate format set (to avoid the crash)

### DIFF
--- a/Shared/LocationTextController.cpp
+++ b/Shared/LocationTextController.cpp
@@ -90,6 +90,9 @@ QString LocationTextController::currentElevationText() const
  */
 void LocationTextController::onLocationChanged(const Point& pt)
 {
+  if (m_coordinateFormat.isEmpty())
+    return;
+
   // update location text
   m_currentLocationText = QString("%1 (%2)").arg(formatCoordinate(pt), m_coordinateFormat);
   emit currentLocationTextChanged();


### PR DESCRIPTION
@ldanzinger please review the fix for missing coordinate format