### PR TITLE
fix assert in debug mode (when list if empty)

### DIFF
--- a/Shared/PointHighlighter.cpp
+++ b/Shared/PointHighlighter.cpp
@@ -64,6 +64,12 @@ void PointHighlighter::startHighlight()
       return;
     }
 
+    if (!m_highlightOverlay || !m_highlightOverlay->graphics() || m_highlightOverlay->graphics()->isEmpty())
+    {
+      m_highlightTimer->stop();
+      return;
+    }
+
     Graphic* graphic = m_highlightOverlay->graphics()->first();
     if (!graphic)
     {


### PR DESCRIPTION
@GuillaumeBelz please review the fix. Calling `first()` was causing an assert in debug mode when the list was empty