### PR TITLE
Remove activeChanged signal from derived tools

### DIFF
--- a/Shared/IdentifyController.h
+++ b/Shared/IdentifyController.h
@@ -57,7 +57,6 @@ private slots:
   void onIdentifyGraphicsOverlaysCompleted(const QUuid& taskId, QList<Esri::ArcGISRuntime::IdentifyGraphicsOverlayResult*> identifyResults);
 
 signals:
-  void activeChanged();
   void busyChanged();
   void popupManagersChanged();
 

--- a/Shared/TelestrateController.cpp
+++ b/Shared/TelestrateController.cpp
@@ -53,6 +53,7 @@ void TelestrateController::setActive(bool active)
   m_active = active;
   GraphicsOverlayListModel* graphicsOverlays = m_geoView->graphicsOverlays();
   active ? graphicsOverlays->append(m_sketchOverlay) : graphicsOverlays->removeOne(m_sketchOverlay);
+  emit activeChanged();
 }
 
 void TelestrateController::setDrawingAltitude(double altitude)

--- a/Shared/TelestrateController.h
+++ b/Shared/TelestrateController.h
@@ -42,7 +42,6 @@ public:
 signals:
   void is3dChanged();
   void drawModeEnabledChanged();
-  void activeChanged();
   void drawingAltitudeChanged();
 
 private:


### PR DESCRIPTION
@michael-tims - please review the updates to remove the now duplicated activeChanged signal from derived tools