### PR TITLE
checking for valid compass

### DIFF
--- a/Shared/LocationController.cpp
+++ b/Shared/LocationController.cpp
@@ -85,6 +85,9 @@ void LocationController::initPositionInfoSource(bool simulated)
 
     connect(m_compass, &QCompass::readingChanged, this, [this]()
     {
+      if (!m_compass)
+        return;
+
       QCompassReading* reading = m_compass->reading();
       if (!reading)
         return;

--- a/Shared/LocationDisplay3d.cpp
+++ b/Shared/LocationDisplay3d.cpp
@@ -158,6 +158,9 @@ void LocationDisplay3d::setCompass(QCompass* compass)
 
   m_headingConnection = connect(m_compass, &QCompass::readingChanged, this, [this]()
   {
+    if (!m_compass)
+      return;
+
     QCompassReading* reading = m_compass->reading();
     if (!reading)
       return;


### PR DESCRIPTION
@michael-tims - Kerry and I found that DSA is crashing on Android. I tracked it down to a segfault in these lambdas, so checking for a valid compass first seems to avoid the issue. I'm not really sure why the compass is null