### PR TITLE
Unselect when alert timer is stopped

### DIFF
--- a/Shared/qml/AlertList.qml
+++ b/Shared/qml/AlertList.qml
@@ -233,5 +233,12 @@ DsaPanel {
             toolController.flashAll(highlightOn);
             highlightOn = !highlightOn;
         }
+
+        onRunningChanged: {
+            if (!running) {
+                highlightOn = false;
+                toolController.flashAll(highlightOn);
+            }
+        }
     }
 }


### PR DESCRIPTION
@ldanzinger please review and merge

This timer toggles selection when running.  But it needs to unselect when it's stopped or else some alerts may stay selected when they shouldn't be.