### PR TITLE
allow query object to be empty (e.g. for within area)

### DIFF
--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -893,9 +893,6 @@ bool AlertConditionsController::addConditionFromJson(const QJsonObject& json)
     return false;
 
   QJsonObject queryObject = json.value(AlertConstants::CONDITION_QUERY).toObject();
-  if (queryObject.isEmpty())
-    return false;
-
   const QVariantMap queryComponents = queryObject.toVariantMap();
 
   if (isAttributeEquals)


### PR DESCRIPTION
@michael-tims please review the fix for parsing within area conditions