### PR TITLE
use the user friendly name for targets

### DIFF
--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -1030,7 +1030,7 @@ AlertTarget* AlertConditionsController::targetFromItemIdAndIndex(int itemId, int
       if (overlay->overlayId().isEmpty())
         continue;
 
-      QString overlayIdOrName = m_messageFeedTypesToNames.value(overlay->overlayId(), overlay->overlayId());
+      const QString overlayIdOrName = m_messageFeedTypesToNames.value(overlay->overlayId(), overlay->overlayId());
 
       ++currIndex;
 


### PR DESCRIPTION
@michael-tims - please review the change to use the user friendly name for message feeds etc. when creating targets