### PR TITLE
Add QtQml.Models import for iOS deployment

### DIFF
--- a/Vehicle/qml/main.qml
+++ b/Vehicle/qml/main.qml
@@ -14,6 +14,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
+import QtQml.Models 2.2
 import Esri.DSA 1.0
 import Esri.Vehicle 1.0
 import Esri.ArcGISRuntime.Toolkit.Controls 100.2


### PR DESCRIPTION
@ldanzinger please review and merge

I'm not sure what the deal is on this import for iOS.  Handheld's main.qml already contains it, but so does Imports.qml.  Without `import QtQml.Models 2.2` in main.qml, iOS will fail to run.  So let's go ahead and add it to the Vehicle's main.qml as well.