### PR TITLE
Dsa alerts:

### DIFF
--- a/Shared/alerts/LocationAlertSource.cpp
+++ b/Shared/alerts/LocationAlertSource.cpp
@@ -32,7 +32,8 @@ using namespace Esri::ArcGISRuntime;
   \brief Constructor taking an optional \a parent.
  */
 LocationAlertSource::LocationAlertSource(QObject* parent):
-  AlertSource(parent)
+  AlertSource(parent),
+  m_location(0., 0., SpatialReference::wgs84())
 {
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::locationChanged, this, [this](const Point& location)
   {


### PR DESCRIPTION
- provide an initial location with a valid SR to avoid crash on startup

@GuillaumeBelz please review the fix