### PR TITLE
Environment tag appended to messageType value

### DIFF
--- a/Shared/messages/Message.cpp
+++ b/Shared/messages/Message.cpp
@@ -38,6 +38,7 @@ const QString Message::GEOMESSAGE_SIC_NAME{QStringLiteral("sic")};
 const QString Message::GEOMESSAGE_CONTROL_POINTS_NAME{QStringLiteral("_control_points")};
 const QString Message::GEOMESSAGE_UNIQUE_DESIGNATION_NAME{QStringLiteral("uniquedesignation")};
 const QString Message::GEOMESSAGE_STATUS_911_NAME{QStringLiteral("status911")};
+const QString Message::GEOMESSAGE_ENVIRONMENT_NAME{QStringLiteral("environment")};
 
 const QString Message::SIDC_NAME{QStringLiteral("sidc")};
 
@@ -225,6 +226,7 @@ Message Message::createFromGeoMessage(const QByteArray& message)
   QVariantMap attributes;
   QString wkidText;
   QString controlPointsText;
+  QString environmentText;
 
   bool inGeoMessageElement = false;
 
@@ -277,6 +279,10 @@ Message Message::createFromGeoMessage(const QByteArray& message)
       {
         controlPointsText = reader.readElementText();
       }
+      else if (QStringRef::compare(reader.name(), GEOMESSAGE_ENVIRONMENT_NAME, Qt::CaseInsensitive) == 0)
+      {
+        environmentText = reader.readElementText();
+      }
       else
       {
         attributes.insert(reader.name().toString(), reader.readElementText());
@@ -291,6 +297,11 @@ Message Message::createFromGeoMessage(const QByteArray& message)
     }
 
     reader.readNext();
+  }
+
+  if (!environmentText.isEmpty())
+  {
+    geoMessage.d->messageType += QString("_%1").arg(environmentText);
   }
 
   if (!controlPointsText.isEmpty())

--- a/Shared/messages/Message.h
+++ b/Shared/messages/Message.h
@@ -42,6 +42,7 @@ public:
   static const QString GEOMESSAGE_CONTROL_POINTS_NAME;
   static const QString GEOMESSAGE_UNIQUE_DESIGNATION_NAME;
   static const QString GEOMESSAGE_STATUS_911_NAME;
+  static const QString GEOMESSAGE_ENVIRONMENT_NAME;
 
   static const QString SIDC_NAME;
 


### PR DESCRIPTION
@ldanzinger please review and merge

There will be a new `<environment>` element added to the GeoMessage spec.  The DSA Message type will read this value and concatenate it with the existing `<_type>` element to form the `Message::messageType` string.  `<environment>` is optional.