### PR TITLE
pitch changes with 360 viewshed

### DIFF
--- a/Shared/analysis/GeoElementViewshed360.cpp
+++ b/Shared/analysis/GeoElementViewshed360.cpp
@@ -201,6 +201,7 @@ void GeoElementViewshed360::update360Mode(bool is360Mode)
 
   emit horizontalAngleChanged();
   emit verticalAngleChanged();
+  emit pitchChanged();
 
   for (auto viewshed : m_viewsheds360Offsets)
   {


### PR DESCRIPTION
@lsmallwood Please review and merge

I found this bug while writing additional unit tests.  The pitch gets reset when the viewshed 360 is enabled.