### PR TITLE
Fix alert conditions for DevSummit demos

### DIFF
--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -141,6 +141,8 @@ QString AlertConditionsController::toolName() const
  */
 void AlertConditionsController::setProperties(const QVariantMap& properties)
 {
+  const auto conditionsData = properties[AlertConstants::ALERT_CONDITIONS_PROPERTYNAME];
+
   const auto messageFeeds = properties[MessageFeedConstants::MESSAGE_FEEDS_PROPERTYNAME].toList();
   if (!messageFeeds.isEmpty())
   {
@@ -148,7 +150,8 @@ void AlertConditionsController::setProperties(const QVariantMap& properties)
     for (const auto& messageFeed : messageFeedsJson)
     {
       const auto messageFeedJsonObject = messageFeed.toObject();
-      if (messageFeedJsonObject.size() != 4)
+      if (!messageFeedJsonObject.contains(MessageFeedConstants::MESSAGE_FEEDS_NAME) ||
+          !messageFeedJsonObject.contains(MessageFeedConstants::MESSAGE_FEEDS_TYPE))
         continue;
 
       const auto feedName = messageFeedJsonObject[MessageFeedConstants::MESSAGE_FEEDS_NAME].toString();
@@ -160,7 +163,6 @@ void AlertConditionsController::setProperties(const QVariantMap& properties)
     onLayersChanged();
   }
 
-  const QVariant conditionsData = properties.value(AlertConstants::ALERT_CONDITIONS_PROPERTYNAME);
   if (conditionsData.isNull())
     return;
 


### PR DESCRIPTION
Fixing alert conditions for DevSummit demos

@lsmallwood Please review when you get a chance.  It might be a good idea for the DsaController to make a copy of the properties before calling `abstractTool->setProperties(m_dsaSettings);`  this is because the map is passed in by reference and could be modified during the processing of the properties by each tool which seemed to be the case for the AlertConditionController.