### PR TITLE
add default case to switch (fix warning)

### DIFF
--- a/Shared/messages/MessagesOverlay.cpp
+++ b/Shared/messages/MessagesOverlay.cpp
@@ -158,6 +158,8 @@ bool MessagesOverlay::addMessage(const Message& message)
           }
           break;
         }
+      default:
+          break;
       }
 
       break;


### PR DESCRIPTION
@GuillaumeBelz please review the fix to remove a warning on linux