### PR TITLE
set the cam ctrllr to the existing position

### DIFF
--- a/Shared/analysis/ViewshedController.cpp
+++ b/Shared/analysis/ViewshedController.cpp
@@ -10,10 +10,10 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-#include "ViewshedController.h"
-
 // PCH header
 #include "pch.hpp"
+
+#include "ViewshedController.h"
 
 // example app headers
 #include "DsaUtility.h"


### PR DESCRIPTION
@GuillaumeBelz please review the change to prevent the camera from jumping when we switch modes