### PR TITLE
Remove coordConversion from the list of conflicting tools

### DIFF
--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -53,7 +53,6 @@ DsaController::DsaController(QObject* parent):
   m_jsonFormat(QSettings::registerFormat("json", &readJsonFile, &writeJsonFile)),
   m_conflictingToolNames{QStringLiteral("Alert Conditions"),
                          QStringLiteral("Markup Tool"),
-                         QStringLiteral("CoordinateConversion"),
                          QStringLiteral("viewshed")}
 {
   // setup config settings


### PR DESCRIPTION
@JamesMBallard please review the change. This allows us to have coordinate conversion open at the same time as other tools which interact with the view