### PR TITLE
These need to be ifdef'd for Windows.

### DIFF
--- a/Handheld/main.cpp
+++ b/Handheld/main.cpp
@@ -58,14 +58,9 @@
 #include <QSettings>
 
 // STL headers
-#include <Windows.h>
-
 #ifdef Q_OS_WIN
+#include <Windows.h>
 #endif
-
-
-
-
 
 //------------------------------------------------------------------------------
 

--- a/Vehicle/main.cpp
+++ b/Vehicle/main.cpp
@@ -58,15 +58,9 @@
 #include <QSettings>
 
 // STL headers
-#include <Windows.h>
-
 #ifdef Q_OS_WIN
+#include <Windows.h>
 #endif
-
-
-
-
-
 
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
Assigned to @michael-tims.

Fix the ifdef so we can build again on non-Windows platforms.