### PR TITLE
Various viewshed/LOS fixes:

### DIFF
--- a/Handheld/qml/main.qml
+++ b/Handheld/qml/main.qml
@@ -261,6 +261,10 @@ Handheld {
             onMyLocationModeSelected: {
                 navTool.startFollowing();
             }
+
+            onClosed: {
+                analysisToolRow.state = "clear";
+            }
         }
 
         LineOfSightTool {

--- a/Shared/analysis/CombinedAnalysisListModel.cpp
+++ b/Shared/analysis/CombinedAnalysisListModel.cpp
@@ -93,6 +93,15 @@ void CombinedAnalysisListModel::setLineOfSightModel(AnalysisListModel* lineOfSig
 
   beginResetModel();
   m_lineOfSightModel = lineOfSightModel;
+
+  // persist a unique index for each Line of sight as they are added - to be used to construct a name
+  connect(m_lineOfSightModel, &AnalysisListModel::analysisAdded, this, [this](int index)
+  {
+    Analysis* addedAnalysis = m_lineOfSightModel->at(index);
+    if (addedAnalysis)
+      m_lineOfSightIndices.insert(addedAnalysis, m_lineOfSightIndices.count() + 1);
+  });
+
   connectAnalysisListModelSignals(m_lineOfSightModel);
   endResetModel();
 }
@@ -202,7 +211,11 @@ QVariant CombinedAnalysisListModel::data(const QModelIndex& index, int role) con
     switch (role)
     {
     case AnalysisNameRole:
-      return QString("Line of Sight %1").arg(QString::number(lineOfSightIndex(index.row())));
+    {
+      Analysis* losPtr = m_lineOfSightModel->at(lineOfSightIndex(index.row()));
+      if (losPtr)
+        return QString("Line of sight %1").arg(m_lineOfSightIndices.value(losPtr));
+    }
     case AnalysisVisibleRole:
       return m_lineOfSightModel->data(m_lineOfSightModel->index(lineOfSightIndex(index.row()), 0), AnalysisListModel::AnalysisRoles::AnalysisVisibleRole);
     case AnalysisTypeRole:

--- a/Shared/analysis/CombinedAnalysisListModel.h
+++ b/Shared/analysis/CombinedAnalysisListModel.h
@@ -75,6 +75,7 @@ private:
   QHash<int, QByteArray> m_roles;
   ViewshedListModel* m_viewshedModel = nullptr;
   Esri::ArcGISRuntime::AnalysisListModel* m_lineOfSightModel = nullptr;
+  QHash<Esri::ArcGISRuntime::Analysis*, int> m_lineOfSightIndices;
 };
 
 } // Dsa

--- a/Shared/analysis/ViewshedController.h
+++ b/Shared/analysis/ViewshedController.h
@@ -63,6 +63,7 @@ class ViewshedController : public Esri::ArcGISRuntime::Toolkit::AbstractTool
   Q_PROPERTY(bool activeViewshedPitchEnabled READ isActiveViewshedPitchEnabled NOTIFY activeViewshedPitchEnabledChanged)
   Q_PROPERTY(bool activeViewshedOffsetZEnabled READ isActiveViewshedOffsetZEnabled NOTIFY activeViewshedOffsetZEnabledChanged)
   Q_PROPERTY(bool activeViewshed360Mode READ isActiveViewshed360Mode WRITE setActiveViewshed360Mode NOTIFY activeViewshed360ModeChanged)
+  Q_PROPERTY(bool locationDisplayViewshedActive READ isLocationDisplayViewshedActive NOTIFY locationDisplayViewshedActiveChanged)
 
 signals:
   void activeModeChanged();
@@ -82,6 +83,7 @@ signals:
   void activeViewshedPitchEnabledChanged();
   void activeViewshedOffsetZEnabledChanged();
   void activeViewshed360ModeChanged();
+  void locationDisplayViewshedActiveChanged();
 
 public:
   enum ViewshedActiveMode
@@ -121,9 +123,6 @@ public:
   Q_INVOKABLE void finishActiveViewshed();
 
   bool isActiveViewshedEnabled() const;
-
-  int activeViewshedIndex() const;
-  void setActiveViewshedIndex(int index);
 
   double activeViewshedMinDistance() const;
   void setActiveViewshedMinDistance(double minDistance);
@@ -179,7 +178,6 @@ private:
   Viewshed360* m_activeViewshed = nullptr;
   GeoElementViewshed360* m_locationDisplayViewshed = nullptr;
 
-  int m_activeViewshedIndex = -1;
   ViewshedActiveMode m_activeMode = ViewshedActiveMode::NoActiveMode;
 
   Esri::ArcGISRuntime::TaskWatcher m_identifyTaskWatcher;

--- a/Shared/qml/Viewshed.qml
+++ b/Shared/qml/Viewshed.qml
@@ -22,6 +22,7 @@ Item {
     property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     signal myLocationModeSelected
+    signal closed
 
     ViewshedController {
         id: toolController
@@ -97,6 +98,8 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 iconUrl: DsaResources.iconCurrentLocation
                 color: "transparent"
+                opacity: enabled ? 1 : 0.5
+                enabled: !toolController.locationDisplayViewshedActive
                 selected: toolController.activeMode === ViewshedController.AddMyLocationViewshed360;
 
                 onClicked: {
@@ -445,6 +448,7 @@ Item {
             onToolSelected: {
                 toolController.finishActiveViewshed();
                 toolController.activeMode = ViewshedController.NoActiveMode;
+                closed();
             }
         }
 
@@ -455,6 +459,7 @@ Item {
             onToolSelected: {
                 toolController.removeActiveViewshed();
                 toolController.activeMode = ViewshedController.NoActiveMode;
+                closed();
             }
         }
     }

--- a/Vehicle/qml/main.qml
+++ b/Vehicle/qml/main.qml
@@ -252,6 +252,10 @@ Vehicle {
             onMyLocationModeSelected: {
                 navTool.startFollowing();
             }
+
+            onClosed: {
+                analysisToolRow.state = "clear";
+            }
         }
 
         LineOfSightTool {


### PR DESCRIPTION
- remove the old activee index system as that was no longer used (just keep the member ptr up-to-date)
- add a property to flag when a location viewshed exists
- lock location UI when a viewshed already exists
- close the viewshed tool on cancel/finish
- persist a name for LOS

@michael-tims please review the various fixes