### PR TITLE
Remove hardcoded height from dialogs to prevent cut off text

### DIFF
--- a/Shared/qml/DsaInputDialog.qml
+++ b/Shared/qml/DsaInputDialog.qml
@@ -29,7 +29,6 @@ Dialog {
     x: appRoot.width / 2 - width / 2
     y: appRoot.height / 2 - height / 2
     width: 250 * scaleFactor
-    height: 120 * scaleFactor
     standardButtons: Dialog.Ok | Dialog.Cancel
 
     Column {

--- a/Shared/qml/DsaMessageDialog.qml
+++ b/Shared/qml/DsaMessageDialog.qml
@@ -26,7 +26,6 @@ Dialog {
     x: appRoot.width / 2 - width / 2
     y: appRoot.height / 2 - height / 2
     width: 250 * scaleFactor
-    height: 125 * scaleFactor
     standardButtons: Dialog.Ok
 
     property alias informativeText: label.text

--- a/Shared/qml/DsaYesNoDialog.qml
+++ b/Shared/qml/DsaYesNoDialog.qml
@@ -26,7 +26,6 @@ Dialog {
     x: appRoot.width / 2 - width / 2
     y: appRoot.height / 2 - height / 2
     width: 250 * scaleFactor
-    height: 140 * scaleFactor
     standardButtons: Dialog.Yes | Dialog.No
 
     property alias informativeText: label.text


### PR DESCRIPTION
This PR removes hard-coded heights so that the dialog boxes will adjust to fit their contents.

@ldanzinger Please review the changes. 