### PR TITLE
Center location buttons in Observation Reports Wizard

### DIFF
--- a/Shared/qml/ObservationReportLocationPage.qml
+++ b/Shared/qml/ObservationReportLocationPage.qml
@@ -71,9 +71,7 @@ Item {
             margins: 8 * scaleFactor
         }
 
-        width: parent.width * 0.5
-
-        spacing: 16 * scaleFactor
+        spacing: 20 * scaleFactor
 
         ToolIcon {
             id: pickButton


### PR DESCRIPTION
This PR is for a slight tweak to the placement and spacing of the location source buttons for the Create Observation Wizard.

@lsmallwood Please review and merge.