### PR TITLE
adding documentation for all Q_PROPERTYs

### DIFF
--- a/Shared/AddLocalDataController.cpp
+++ b/Shared/AddLocalDataController.cpp
@@ -101,6 +101,7 @@ AddLocalDataController::AddLocalDataController(QObject* parent /* = nullptr */):
 }
 
 /*!
+ \property AddLocalDataController::localDataModel
  \brief Returns the local data model associated with the controller.
  */
 QAbstractListModel* AddLocalDataController::localDataModel() const
@@ -152,6 +153,7 @@ void AddLocalDataController::refreshLocalDataModel(const QString& fileType)
 }
 
 /*!
+ \property AddLocalDataController::fileFilterList
  \brief Returns the file filter string list for filtering data from the QDir entrylist
  */
 QStringList AddLocalDataController::determineFileFilters(const QString& fileType)

--- a/Shared/BasemapPickerController.cpp
+++ b/Shared/BasemapPickerController.cpp
@@ -136,6 +136,7 @@ void BasemapPickerController::onBasemapDataPathChanged()
 }
 
 /*!
+  \property BasemapPickerController::localDataModel
   \brief Returns a model of the local tile cache files contained in the
   basemap data directory.
  */

--- a/Shared/ContextMenuController.cpp
+++ b/Shared/ContextMenuController.cpp
@@ -338,6 +338,7 @@ void ContextMenuController::clearOptions()
 }
 
 /*!
+  \property ContextMenuController::resultTitle
   \brief Returns the title of the current context action.
  */
 QString ContextMenuController::resultTitle() const
@@ -442,6 +443,7 @@ Point ContextMenuController::contextLocation() const
 }
 
 /*!
+  \property ContextMenuController::result
   \brief Returns the result of the current action (if applicable).
  */
 QString ContextMenuController::result() const
@@ -461,6 +463,7 @@ void ContextMenuController::setResult(const QString& result)
 }
 
 /*!
+  \property ContextMenuController::options
   \brief Returns the current list of actions which can be performed for this context
  */
 QStringListModel* ContextMenuController::options() const
@@ -569,6 +572,7 @@ void ContextMenuController::selectOption(const QString& option)
 }
 
 /*!
+  \property ContextMenuController::contextScreenPosition
   \brief Returns the screen position for the current context.
  */
 QPoint ContextMenuController::contextScreenPosition() const
@@ -577,6 +581,7 @@ QPoint ContextMenuController::contextScreenPosition() const
 }
 
 /*!
+  \property ContextMenuController::contextActive
   \brief Returns whether the current context is active or not.
  */
 bool ContextMenuController::isContextActive() const

--- a/Shared/FollowPositionController.cpp
+++ b/Shared/FollowPositionController.cpp
@@ -80,6 +80,7 @@ void FollowPositionController::setFollowMode(FollowPositionController::FollowMod
 }
 
 /*!
+  \property FollowPositionController::followMode
   \brief Returns the follow mode for the tool.
  */
 FollowPositionController::FollowMode FollowPositionController::followMode() const

--- a/Shared/IdentifyController.cpp
+++ b/Shared/IdentifyController.cpp
@@ -99,6 +99,7 @@ void IdentifyController::setActive(bool active)
 }
 
 /*!
+  \property IdentifyController::busy
   \brief Returns whether the tool is busy or not (e.g. whether identify tasks are running).
  */
 bool IdentifyController::busy() const
@@ -108,6 +109,7 @@ bool IdentifyController::busy() const
 }
 
 /*!
+  \property IdentifyController::popupManagers
   \brief Returns a QVariantList of \l Esri::ArcGISRuntime::PopupManager which can be displayed in the view.
 
   For example, this can be passed to a \l PopupView or \l PopupStackView for display.

--- a/Shared/LocationController.cpp
+++ b/Shared/LocationController.cpp
@@ -202,6 +202,7 @@ void LocationController::setProperties(const QVariantMap& properties)
 }
 
 /*!
+  \property LocationController::enabled
   \brief Returns whether the tool is enabled.
  */
 bool LocationController::isEnabled() const
@@ -237,6 +238,7 @@ void LocationController::setEnabled(bool enabled)
 }
 
 /*!
+  \property LocationController::locationVisible
   \brief Returns whether the location is visible.
  */
 bool LocationController::isLocationVisible() const
@@ -261,6 +263,7 @@ void LocationController::setLocationVisible(bool visible)
 }
 
 /*!
+  \property LocationController::simulationEnabled
   \brief Returns whether the location is simulated.
  */
 bool LocationController::isSimulationEnabled() const
@@ -312,6 +315,7 @@ LocationDisplay3d* LocationController::locationDisplay() const
 }
 
 /*!
+  \property LocationController::gpxFilePath
   \brief Returns the file path of the GPX file.
  */
 QString LocationController::gpxFilePath() const

--- a/Shared/LocationTextController.cpp
+++ b/Shared/LocationTextController.cpp
@@ -84,6 +84,7 @@ QString LocationTextController::toolName() const
 }
 
 /*!
+ \property LocationTextController::currentLocationText
  \brief Returns the location text string for display in QML.
  */
 QString LocationTextController::currentLocationText() const
@@ -92,6 +93,7 @@ QString LocationTextController::currentLocationText() const
 }
 
 /*!
+ \property LocationTextController::currentElevationText
  \brief Returns the elevation text string for display in QML.
  */
 QString LocationTextController::currentElevationText() const

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -358,6 +358,7 @@ void NavigationController::zoom()
 }
 
 /*!
+  \property NavigationController::vertical
   \brief Returns whether the camera is vertical.
  */
 bool NavigationController::isVertical() const
@@ -366,6 +367,7 @@ bool NavigationController::isVertical() const
 }
 
 /*!
+  \property NavigationController::zoomFactor
   \brief Returns the zoom factor.
  */
 double NavigationController::zoomFactor() const
@@ -386,6 +388,7 @@ void NavigationController::setZoomFactor(double value)
 }
 
 /*!
+  \property NavigationController::cameraMoveDistance
   \brief Returns the camera move distance in meters.
  */
 double NavigationController::cameraMoveDistance() const

--- a/Shared/OptionsController.cpp
+++ b/Shared/OptionsController.cpp
@@ -128,6 +128,7 @@ void OptionsController::setProperties(const QVariantMap& properties)
 }
 
 /*!
+ \property OptionsController::coordinateFormats
  \brief Returns the coordinate format list for display in the combo box.
  */
 QStringList OptionsController::coordinateFormats() const
@@ -147,6 +148,7 @@ void OptionsController::setCoordinateFormat(const QString& format)
 }
 
 /*!
+  \property OptionsController::useGpsForElevation
  \brief Returns whether to use GPS for elevation for display.
  */
 bool OptionsController::useGpsForElevation() const
@@ -169,6 +171,7 @@ void OptionsController::setUseGpsForElevation(bool useGps)
 }
 
 /*!
+  \property OptionsController::units
  \brief Returns the unit of measurement list for display.
  */
 QStringList OptionsController::units() const
@@ -188,6 +191,7 @@ void OptionsController::setUnitOfMeasurement(const QString& unit)
 }
 
 /*!
+ \property OptionsController::userName
  \brief Returns the user name for the app.
  */
 QString OptionsController::userName() const
@@ -209,6 +213,7 @@ void OptionsController::setUserName(const QString& userName)
 }
 
 /*!
+  \property OptionsController::initialFormatIndex
  \brief Returns the initial index.
   This is used to set the initial index in the combo box to match the controller.
   */
@@ -218,6 +223,7 @@ int OptionsController::initialFormatIndex() const
 }
 
 /*!
+  \property OptionsController::initialUnitIndex
  \brief Returns the initial index of the list of units.
 
   This is used to set the initial index in the combo box to match the controller.
@@ -228,6 +234,7 @@ int OptionsController::initialUnitIndex() const
 }
 
 /*!
+  \property OptionsController::showFriendlyTracksLabels
  \brief Returns whether the friendly tracks labels show.
 */
 bool OptionsController::showFriendlyTracksLabels()

--- a/Shared/TableOfContentsController.cpp
+++ b/Shared/TableOfContentsController.cpp
@@ -68,6 +68,7 @@ TableOfContentsController::~TableOfContentsController()
 }
 
 /*!
+  \property TableOfContentsController::layerListModel
   \brief Returns the list of operational layers in draw order.
  */
 QAbstractItemModel* TableOfContentsController::layerListModel() const

--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -469,6 +469,7 @@ void AlertConditionsController::updateConditionLevel(int rowIndex, int level)
 }
 
 /*!
+  \property AlertConditionsController::sourceNames
   \brief Returns a QAbstractItemModel containing the list of
   names for creating condition sources.
 
@@ -480,6 +481,7 @@ QAbstractItemModel* AlertConditionsController::sourceNames() const
 }
 
 /*!
+  \property AlertConditionsController::targetNames
   \brief Returns a QAbstractItemModel containing the list of
   names for creating condition targets.
 
@@ -491,6 +493,7 @@ QAbstractItemModel* AlertConditionsController::targetNames() const
 }
 
 /*!
+  \property AlertConditionsController::levelNames
   \brief Returns a QAbstractItemModel containing the list of
   level names for creating condition targets.
 
@@ -502,6 +505,7 @@ QAbstractItemModel* AlertConditionsController::levelNames() const
 }
 
 /*!
+  \property AlertConditionsController::conditionsList
   \brief Returns a QAbstractItemModel containing the list of
   conditions.
 
@@ -513,6 +517,7 @@ QAbstractItemModel* AlertConditionsController::conditionsList() const
 }
 
 /*!
+  \property AlertConditionsController::pickMode
   \brief Returns whether the tool is in pick mode or not.
  */
 bool AlertConditionsController::pickMode() const

--- a/Shared/alerts/AlertListController.cpp
+++ b/Shared/alerts/AlertListController.cpp
@@ -91,6 +91,7 @@ AlertListController::~AlertListController()
 }
 
 /*!
+  \property AlertListController::alertListModel
   \brief Returns a model containing the filtered list of active alert condition data.
  */
 QAbstractItemModel* AlertListController::alertListModel() const
@@ -99,6 +100,7 @@ QAbstractItemModel* AlertListController::alertListModel() const
 }
 
 /*!
+  \property AlertListController::allAlertsCount
   \brief Returns the count of all alerts - ignoring any filters.
  */
 int AlertListController::allAlertsCount() const

--- a/Shared/alerts/ViewedAlertsController.cpp
+++ b/Shared/alerts/ViewedAlertsController.cpp
@@ -84,6 +84,7 @@ ViewedAlertsController::~ViewedAlertsController()
 }
 
 /*!
+  \property ViewedAlertsController::unviewedCount
   \brief Returns the number of alert condition data objects which are currently active
   and which have not been marked as viewed.
  */

--- a/Shared/analysis/AnalysisListController.cpp
+++ b/Shared/analysis/AnalysisListController.cpp
@@ -80,6 +80,7 @@ QString AnalysisListController::toolName() const
 }
 
 /*!
+  \property ViewedAlertsController::analysisList
   \brief Returns the list of analyses.
  */
 QAbstractItemModel* AnalysisListController::analysisList() const

--- a/Shared/analysis/LineOfSightController.cpp
+++ b/Shared/analysis/LineOfSightController.cpp
@@ -64,6 +64,7 @@ void LineOfSightController::getLocationGeoElement()
 }
 
 /*!
+  \property LineOfSightController::visibleByCount
   \brief Returns the number of line of sight analyses from features to the current position
   which are unobstructed.
  */
@@ -361,6 +362,7 @@ void LineOfSightController::lineOfSightFromLocationToGeoElement(GeoElement* geoE
 }
 
 /*!
+  \property LineOfSightController::analysisVisible
   \brief Returns whether the results of Line of sight analysis should be visible.
  */
 bool LineOfSightController::isAnalysisVisible() const
@@ -401,6 +403,7 @@ void LineOfSightController::setAnalysisVisible(bool analysisVisible)
 }
 
 /*!
+  \property LineOfSightController::overlayNames
   \brief Returns the list of overlay names which are suitable for Line of sight analysis.
  */
 QAbstractItemModel* LineOfSightController::overlayNames() const

--- a/Shared/analysis/Viewshed360.cpp
+++ b/Shared/analysis/Viewshed360.cpp
@@ -75,6 +75,7 @@ void Viewshed360::removeFromOverlay()
 }
 
 /*!
+  \property Viewshed360::visible
   \brief Returns whether the viewshed is visible.
  */
 bool Viewshed360::isVisible() const
@@ -101,6 +102,7 @@ void Viewshed360::setVisible(bool visible)
 }
 
 /*!
+  \property Viewshed360::name
   \brief Returns the name of the viewshed.
  */
 QString Viewshed360::name() const
@@ -122,6 +124,7 @@ void Viewshed360::setName(const QString& name)
 }
 
 /*!
+  \property Viewshed360::minDistance
   \brief Returns the minimum distance in meters from the observer at which visibility will be evaluated.
  */
 double Viewshed360::minDistance() const
@@ -148,6 +151,7 @@ void Viewshed360::setMinDistance(double minDistance)
 }
 
 /*!
+  \property Viewshed360::maxDistance
   \brief Returns the maximum distance in meters from the observer at which visibility will be evaluated.
  */
 double Viewshed360::maxDistance() const
@@ -174,6 +178,7 @@ void Viewshed360::setMaxDistance(double maxDistance)
 }
 
 /*!
+  \property Viewshed360::horizontalAngle
   \brief Returns the horizontal angle in degrees of the observer's field of vision.
  */
 double Viewshed360::horizontalAngle() const
@@ -206,6 +211,7 @@ void Viewshed360::setHorizontalAngle(double horizontalAngle)
 }
 
 /*!
+  \property Viewshed360::verticalAngle
   \brief Returns the vertical angle in degrees of the observer's field of vision.
  */
 double Viewshed360::verticalAngle() const
@@ -238,6 +244,7 @@ void Viewshed360::setVerticalAngle(double verticalAngle)
 }
 
 /*!
+  \property Viewshed360::offsetZ
   \brief Returns the offset Z value of the viewshed in meters.
 
   The default value is \c 0.0.
@@ -258,6 +265,7 @@ void Viewshed360::setOffsetZ(double)
 }
 
 /*!
+  \property Viewshed360::headingEnabled
   \brief Returns whether heading is enabled for the viewshed.
 
   Heading will not be used if the viewshed is in 360 degree mode.
@@ -268,6 +276,7 @@ bool Viewshed360::isHeadingEnabled() const
 }
 
 /*!
+  \property Viewshed360::pitchEnabled
   \brief Returns whether pitch is enabled for the viewshed.
 
   Pitch will not be used if the viewshed is in 360 degree mode.
@@ -278,6 +287,7 @@ bool Viewshed360::isPitchEnabled() const
 }
 
 /*!
+  \property Viewshed360::offsetEnabled
   \brief Returns whether offset z is enabled for the viewshed.
  */
 bool Viewshed360::isOffsetZEnabled() const
@@ -286,6 +296,7 @@ bool Viewshed360::isOffsetZEnabled() const
 }
 
 /*!
+  \property Viewshed360::is360Mode
   \brief Returns whether the viewshed is in 360 degree mode.
  */
 bool Viewshed360::is360Mode() const

--- a/Shared/analysis/ViewshedController.cpp
+++ b/Shared/analysis/ViewshedController.cpp
@@ -338,6 +338,7 @@ void ViewshedController::addGeoElementViewshed360(GeoElement* geoElement)
 }
 
 /*!
+  \property ViewshedController::locationDisplayViewshedActive
   \brief Returns whether a viewshed exists for the app's current position.
  */
 bool ViewshedController::isLocationDisplayViewshedActive() const
@@ -346,6 +347,7 @@ bool ViewshedController::isLocationDisplayViewshedActive() const
 }
 
 /*!
+  \property ViewshedController::activeMode
   \brief Returns the active mode for the tool - that is the kind of viewshed
   which will be created.
  */
@@ -388,6 +390,7 @@ void ViewshedController::setActiveMode(ViewshedActiveMode mode)
 }
 
 /*!
+  \property ViewshedController::viewsheds
   \brief Returns a model containing the current list of viewsheds.
  */
 QAbstractListModel* ViewshedController::viewsheds() const
@@ -436,6 +439,7 @@ void ViewshedController::finishActiveViewshed()
 }
 
 /*!
+  \property ViewshedController::activeViewshedEnabled
   \brief Returns whether there is an active viewshed.
  */
 bool ViewshedController::isActiveViewshedEnabled() const
@@ -444,6 +448,7 @@ bool ViewshedController::isActiveViewshedEnabled() const
 }
 
 /*!
+  \property ViewshedController::activeViewshedMinDistance
   \brief Returns the minimum distance of the active viewshed in meters.
 
   If there is no active viewshed this will be \c NAN.
@@ -467,6 +472,7 @@ void ViewshedController::setActiveViewshedMinDistance(double minDistance)
 }
 
 /*!
+  \property ViewshedController::activeViewshedMaxDistance
   \brief Returns the maximum distance of the active viewshed in meters.
 
   If there is no active viewshed this will be \c NAN.
@@ -490,6 +496,7 @@ void ViewshedController::setActiveViewshedMaxDistance(double maxDistance)
 }
 
 /*!
+  \property ViewshedController::activeViewshedHorizontalAngle
   \brief Returns the horizontal angle of the active viewshed in degrees.
 
   If there is no active viewshed this will be \c NAN.
@@ -516,6 +523,7 @@ void ViewshedController::setActiveViewshedHorizontalAngle(double horizontalAngle
 }
 
 /*!
+  \property ViewshedController::activeViewshedVerticalAngle
   \brief Returns the vertical angle of the active viewshed in degrees.
 
   If there is no active viewshed this will be \c NAN.
@@ -542,6 +550,7 @@ void ViewshedController::setActiveViewshedVerticalAngle(double verticalAngle)
 }
 
 /*!
+  \property ViewshedController::activeViewshedHeading
   \brief Returns the heading of the active viewshed in degrees.
 
   If there is no active viewshed this will be \c NAN.
@@ -568,6 +577,7 @@ void ViewshedController::setActiveViewshedHeading(double heading)
 }
 
 /*!
+  \property ViewshedController::activeViewshedPitch
   \brief Returns the pitch of the active viewshed in degrees.
 
   If there is no active viewshed this will be \c NAN.
@@ -594,6 +604,7 @@ void ViewshedController::setActiveViewshedPitch(double pitch)
 }
 
 /*!
+  \property ViewshedController::activeViewshedMinPitch
   \brief Returns the minimum pitch of the active viewshed in degrees.
 
   If there is no active viewshed this will be \c NAN.
@@ -613,6 +624,7 @@ double ViewshedController::activeViewshedMinPitch() const
 }
 
 /*!
+  \property ViewshedController::activeViewshedMaxPitch
   \brief Returns the maximum pitch of the active viewshed in degrees.
 
   If there is no active viewshed this will be \c NAN.
@@ -632,6 +644,7 @@ double ViewshedController::activeViewshedMaxPitch() const
 }
 
 /*!
+  \property ViewshedController::activeViewshedOffsetZ
   \brief Returns the offset z of the active viewshed in meters.
 
   If there is no active viewshed this will be \c 0.0.
@@ -656,6 +669,7 @@ void ViewshedController::setActiveViewshedOffsetZ(double offsetZ)
 }
 
 /*!
+  \property ViewshedController::activeViewshedHeadingEnabled
   \brief Returns whether heading is enabled for the active viewshed.
 
   If there is no active viewshed this will be \c false.
@@ -676,6 +690,7 @@ bool ViewshedController::isActiveViewshedPitchEnabled() const
 }
 
 /*!
+  \property ViewshedController::activeViewshedOffsetZEnabled
   \brief Returns whether offset z is enabled for the active viewshed.
 
   If there is no active viewshed this will be \c false.
@@ -686,6 +701,7 @@ bool ViewshedController::isActiveViewshedOffsetZEnabled() const
 }
 
 /*!
+  \property ViewshedController::isActiveViewshed360Mode
   \brief Returns whether the active viewshed is in 360 degree mode.
 
   If there is no active viewshed this will be \c true.

--- a/Shared/analysis/ViewshedListModel.cpp
+++ b/Shared/analysis/ViewshedListModel.cpp
@@ -164,6 +164,7 @@ void ViewshedListModel::clear()
 }
 
 /*!
+  \property ViewshedListModel::count
   \brief Returns the number of rows in the model.
  */
 int ViewshedListModel::rowCount(const QModelIndex&) const

--- a/Shared/markup/MarkupController.cpp
+++ b/Shared/markup/MarkupController.cpp
@@ -121,6 +121,7 @@ void MarkupController::setDrawingAltitude(double altitude)
 }
 
 /*!
+  \property MarkupController::drawingAltitude
  \brief Returns the drawing altitude.
  */
 double MarkupController::drawingAltitude() const
@@ -361,6 +362,7 @@ void MarkupController::updateGeoView()
 }
 
 /*!
+  \property MarkupController::is3d
  \brief Returns whether the app is 3D.
  */
 bool MarkupController::is3d() const
@@ -377,6 +379,7 @@ int MarkupController::sketchCount() const
 }
 
 /*!
+  \property MarkupController::drawModeEnabled
  \brief Returns whether drawing is enabled.
  */
 bool MarkupController::drawModeEnabled() const
@@ -416,6 +419,7 @@ void MarkupController::setOverlayName(const QString& name)
 }
 
 /*!
+  \property MarkupController::colors
  \brief Returns the list of colors available for markups.
  */
 QStringList MarkupController::colors() const

--- a/Shared/messages/MessageFeedsController.cpp
+++ b/Shared/messages/MessageFeedsController.cpp
@@ -85,6 +85,7 @@ void MessageFeedsController::setGeoView(GeoView* geoView)
 }
 
 /*!
+  \property MessageFeedsController::messageFeeds
   \brief Returns the message feeds list model.
  */
 QAbstractListModel* MessageFeedsController::messageFeeds() const
@@ -266,6 +267,7 @@ LocationBroadcast* MessageFeedsController::locationBroadcast() const
 }
 
 /*!
+  \property MessageFeedsController::locationBroadcastEnabled
   \brief Returns \c true if the location broadcast is enabled.
 
   \sa LocationBroadcast::isEnabled
@@ -291,6 +293,7 @@ void MessageFeedsController::setLocationBroadcastEnabled(bool enabled)
 }
 
 /*!
+  \property MessageFeedsController::locationBroadcastFrequency
   \brief Returns the location broadcast frequency.
 
   \sa LocationBroadcast::frequency
@@ -316,6 +319,7 @@ void MessageFeedsController::setLocationBroadcastFrequency(int frequency)
 }
 
 /*!
+  \property MessageFeedsController::locationBroadcastInDistress
   \brief Returns \c true if the location broadcast reports
   message status as being in distress.
  */

--- a/Shared/messages/ObservationReportController.cpp
+++ b/Shared/messages/ObservationReportController.cpp
@@ -114,6 +114,7 @@ void ObservationReportController::setProperties(const QVariantMap& properties)
 }
 
 /*!
+  \property ObservationReportController::observedBy
   \brief Returns the name of the unit making the observation report.
  */
 QString ObservationReportController::observedBy() const
@@ -122,6 +123,7 @@ QString ObservationReportController::observedBy() const
 }
 
 /*!
+  \property ObservationReportController::controlPoint
   \brief Returns the control point location of the observation report in decimal degrees.
  */
 QString ObservationReportController::controlPoint() const
@@ -164,6 +166,7 @@ void ObservationReportController::setControlPoint(const Point& controlPoint)
 }
 
 /*!
+  \property ObservationReportController::pickMode
   \brief Returns whether the tool is in pick mode. If \c true,
   the tool will use clicks in the geoView to update the \l controlPoint.
  */


### PR DESCRIPTION
@tdunn please review/merge. This is adding the tag for all Q_PROPERTY items, so that the doc properly shows the properties that are accessible from the QML side. This will ultimately show up like they do for the few classes we have in the C++ API that have Q_PROPERTYs, e.g. https://developers.arcgis.com/qt/latest/cpp/api-reference/esri-arcgisruntime-authenticationmanager.html#properties