### PR TITLE
No reason to do a calculation of when the drawer is visible, just use…

### DIFF
--- a/Handheld/qml/main.qml
+++ b/Handheld/qml/main.qml
@@ -383,7 +383,7 @@ Handheld {
             width: parent.width
             height: parent.height - topToolbar.height
             edge: Qt.BottomEdge
-            interactive: y >= topToolbar.height
+            interactive: visible
 
             onClosed: {
                 // update state for each category

--- a/Vehicle/qml/main.qml
+++ b/Vehicle/qml/main.qml
@@ -365,7 +365,7 @@ Vehicle {
             height: sceneView.height - 20 * scaleFactor // approximation for attribution text
             edge: Qt.RightEdge
             y: topToolbar.height
-            interactive: x < appRoot.width
+            interactive: visible
 
             onClosed: {
                 // update state for each category


### PR DESCRIPTION
… the property

The visible property means the same thing as these statements and avoids
a strange problem in the Vehicle app where it can get into a frozen UI state if you click
in one specific area.

Assigned to @michael-tims , please review.

The Handheld app didn't have the same UI problem as Vehicle, but using the `visible` property should be identical to the manual binding calculation being used. I tested this on all platforms (both apps) and everything still works correctly.