### PR TITLE
James/cancel viewshed mode

### DIFF
--- a/Shared/qml/Viewshed.qml
+++ b/Shared/qml/Viewshed.qml
@@ -36,6 +36,11 @@ Item {
         }
     }
 
+    function cancelViewshed() {
+        toolController.removeActiveViewshed();
+        toolController.activeMode = ViewshedController.NoActiveMode;
+    }
+
     DropShadow {
         anchors.fill: fill
         horizontalOffset: -1 * scaleFactor
@@ -79,7 +84,7 @@ Item {
 
         onVisibleChanged: {
             if (!visible)
-                toolController.activeMode = ViewshedController.NoActiveMode;
+                cancelViewshed();
         }
 
         anchors {
@@ -474,8 +479,7 @@ Item {
             iconSource: DsaResources.iconClose
             toolName: "Cancel"
             onToolSelected: {
-                toolController.removeActiveViewshed();
-                toolController.activeMode = ViewshedController.NoActiveMode;
+                cancelViewshed();
                 closed();
             }
         }


### PR DESCRIPTION
Assigned to @michael-tims, please review/merge.

This fixes an issue where the UI could get out of sync. Now if you navigate away from the "Add new viewshed to" dialog without clicking "Finish", it will behave the same as if the user clicked Cancel.