### PR TITLE
Disable swipe/flick interaction with the Drawer.

### DIFF
--- a/Handheld/qml/main.qml
+++ b/Handheld/qml/main.qml
@@ -383,7 +383,7 @@ Handheld {
             width: parent.width
             height: parent.height - topToolbar.height
             edge: Qt.BottomEdge
-            interactive: visible
+            interactive: false
 
             onClosed: {
                 // update state for each category

--- a/Vehicle/qml/main.qml
+++ b/Vehicle/qml/main.qml
@@ -364,7 +364,7 @@ Vehicle {
             height: sceneView.height - 20 * scaleFactor // approximation for attribution text
             edge: Qt.RightEdge
             y: topToolbar.height
-            interactive: visible
+            interactive: false
 
             onClosed: {
                 // update state for each category


### PR DESCRIPTION
@JamesMBallard please review and merge

Disable swipe/flick interaction with the Drawer.  It's causing problems where menus don't react to touch on certain Windows touchscreen tablets.  Since we aren't heavily relying on the swipe behavior of the Drawer in DSA v1.0, this seems like a safe fix to just disable it.

cc: @lsmallwood @ldanzinger 