### PR TITLE
Jame5907/adjust setup timing

### DIFF
--- a/Shared/AddLocalDataController.cpp
+++ b/Shared/AddLocalDataController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -91,8 +92,6 @@ AddLocalDataController::AddLocalDataController(QObject* parent /* = nullptr */):
   Toolkit::AbstractTool(parent),
   m_localDataModel(new DataItemListModel(this))
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   // add the base path to the string list
   addPathToDirectoryList(DsaUtility::dataPath());
 
@@ -103,6 +102,8 @@ AddLocalDataController::AddLocalDataController(QObject* parent /* = nullptr */):
       /*, vectorTilePackageData()*/}; // VTPK is not supported in 3D
   emit fileFilterListChanged();
   emit localDataModelChanged();
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!
@@ -890,5 +891,4 @@ void AddLocalDataController::setProperties(const QVariantMap& properties)
   An \a errorMessage and \a additionalMessage are passed through as parameters, describing
   the error that occurred.
  */
-
 

--- a/Shared/BasemapPickerController.cpp
+++ b/Shared/BasemapPickerController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -56,9 +57,9 @@ BasemapPickerController::BasemapPickerController(QObject* parent /* = nullptr */
   Toolkit::AbstractTool(parent),
   m_tileCacheModel(new TileCacheListModel(this))
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   connect(this, &BasemapPickerController::basemapsDataPathChanged, this, &BasemapPickerController::onBasemapDataPathChanged);
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/ContextMenuController.cpp
+++ b/Shared/ContextMenuController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -13,7 +14,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ******************************************************************************/
-
 
 // PCH header
 #include "pch.hpp"
@@ -87,8 +87,6 @@ ContextMenuController::ContextMenuController(QObject* parent /* = nullptr */):
   Toolkit::AbstractTool(parent),
   m_options(new QStringListModel(this))
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   Toolkit::ToolResourceProvider* resourceProvider = Toolkit::ToolResourceProvider::instance();
   // setup connection to handle mouse-clicking in the view (used to trigger the identify tasks)
   connect(resourceProvider, &Toolkit::ToolResourceProvider::mousePressedAndHeld,
@@ -107,6 +105,8 @@ ContextMenuController::ContextMenuController(QObject* parent /* = nullptr */):
           this, &ContextMenuController::onScreenToLocationCompleted);
 
   m_active = true;
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!
@@ -263,7 +263,6 @@ void ContextMenuController::onIdentifyGraphicsOverlaysCompleted(const QUuid& tas
   processGeoElements();
 }
 
-
 /*!
   \internal
 
@@ -277,7 +276,6 @@ void ContextMenuController::onScreenToLocationCompleted(QUuid taskId, const Poin
   m_screenToLocationTask = TaskWatcher();
   setContextLocation(location);
 }
-
 
 /*!
   \brief Update the context information for the clicked screen position.

--- a/Shared/FollowPositionController.cpp
+++ b/Shared/FollowPositionController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -47,12 +48,12 @@ namespace Dsa {
 FollowPositionController::FollowPositionController(QObject* parent) :
   Toolkit::AbstractTool(parent)
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::geoViewChanged, this,
           &FollowPositionController::updateGeoView);
 
   updateGeoView();
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/IdentifyController.cpp
+++ b/Shared/IdentifyController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -51,8 +52,6 @@ namespace Dsa {
 IdentifyController::IdentifyController(QObject* parent /* = nullptr */):
   Toolkit::AbstractTool(parent)
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   // setup connection to handle mouse-clicking in the view (used to trigger the identify tasks)
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::mouseClicked,
           this, &IdentifyController::onMouseClicked);
@@ -64,6 +63,8 @@ IdentifyController::IdentifyController(QObject* parent /* = nullptr */):
   // setup connection to handle the results of an Identify Graphic Overlays task
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::identifyGraphicsOverlaysCompleted,
           this, &IdentifyController::onIdentifyGraphicsOverlaysCompleted);
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/LayerCacheManager.cpp
+++ b/Shared/LayerCacheManager.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -76,8 +77,6 @@ using namespace Esri::ArcGISRuntime;
 LayerCacheManager::LayerCacheManager(QObject* parent) :
   Toolkit::AbstractTool(parent)
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   // obtain Add Local Data Controller
   m_localDataController = Toolkit::ToolManager::instance().tool<AddLocalDataController>();
 
@@ -114,6 +113,8 @@ LayerCacheManager::LayerCacheManager(QObject* parent) :
     connect(m_scene->operationalLayers(), &LayerListModel::layoutChanged, this, &LayerCacheManager::onLayerListChanged); // order changed
     connect(m_scene->operationalLayers(), &LayerListModel::modelReset, this, &LayerCacheManager::onLayerListChanged); // order changed
   }
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/LocationController.cpp
+++ b/Shared/LocationController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -65,12 +66,12 @@ LocationController::LocationController(QObject* parent) :
   Toolkit::AbstractTool(parent),
   m_locationDisplay3d(new LocationDisplay3d(this))
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   connect(this, &LocationController::locationChanged, Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::onLocationChanged);
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::geoViewChanged, this, &LocationController::updateGeoView);
 
   updateGeoView();
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/LocationTextController.cpp
+++ b/Shared/LocationTextController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -64,13 +65,13 @@ LocationTextController::LocationTextController(QObject* parent) :
   m_coordinateFormat(DMS),
   m_unitOfMeasurement(Meters)
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::geoViewChanged,
           this, &LocationTextController::onGeoViewChanged);
 
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::locationChanged,
           this, &LocationTextController::onLocationChanged);
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -62,8 +63,6 @@ NavigationController::NavigationController(QObject* parent) :
   Toolkit::AbstractTool(parent),
   m_initialCenter(DsaUtility::montereyCA())
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::sceneChanged, this, &NavigationController::setInitialLocation);
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::mapChanged, this, &NavigationController::setInitialLocation);
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::geoViewChanged, this, &NavigationController::updateGeoView);
@@ -71,6 +70,8 @@ NavigationController::NavigationController(QObject* parent) :
 
   updateGeoView();
   setInitialLocation();
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/OptionsController.cpp
+++ b/Shared/OptionsController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -62,9 +63,9 @@ OptionsController::OptionsController(QObject* parent) :
   m_units{AppConstants::UNIT_METERS,
           AppConstants::UNIT_FEET}
 {
-  Toolkit::ToolManager::instance().addTool(this);
   emit unitsChanged();
   emit coordinateFormatsChanged();
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/TableOfContentsController.cpp
+++ b/Shared/TableOfContentsController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -57,13 +58,13 @@ namespace Dsa {
 TableOfContentsController::TableOfContentsController(QObject* parent /* = nullptr */):
   Toolkit::AbstractTool(parent)
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::mapChanged,
           this, &TableOfContentsController::updateLayerListModel);
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::sceneChanged,
           this, &TableOfContentsController::updateLayerListModel);
   updateLayerListModel();
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -89,8 +90,6 @@ AlertConditionsController::AlertConditionsController(QObject* parent /* = nullpt
   m_locationSource(new LocationAlertSource(this)),
   m_locationTarget(new LocationAlertTarget(this))
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::geoViewChanged,
           this, &AlertConditionsController::onGeoviewChanged);
 
@@ -100,6 +99,8 @@ AlertConditionsController::AlertConditionsController(QObject* parent /* = nullpt
   connect(m_conditions, &AlertConditionListModel::dataChanged, this, &AlertConditionsController::onConditionsChanged);
 
   onGeoviewChanged();
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/alerts/AlertListController.cpp
+++ b/Shared/alerts/AlertListController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -75,7 +76,6 @@ AlertListController::AlertListController(QObject* parent /* = nullptr */):
   m_idsAlertFilter(new IdsAlertFilter(this)),
   m_highlighter(new PointHighlighter(this))
 {
-  Toolkit::ToolManager::instance().addTool(this);
   m_filters.append(m_statusAlertFilter);
   m_filters.append(m_idsAlertFilter);
 
@@ -86,6 +86,8 @@ AlertListController::AlertListController(QObject* parent /* = nullptr */):
   connect(AlertListModel::instance(), &AlertListModel::rowsInserted, this, &AlertListController::allAlertsCountChanged);
   connect(AlertListModel::instance(), &AlertListModel::rowsRemoved, this, &AlertListController::allAlertsCountChanged);
   emit allAlertsCountChanged();
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!
@@ -274,7 +276,6 @@ void AlertListController::dismiss(int rowIndex)
   m_idsAlertFilter->addId(alert->id());
   m_alertsProxyModel->applyFilter(m_filters);
 }
-
 
 /*!
   \brief Sets the minimum \l AlertLevel for the current \l StatusAlertFilter to \a level.

--- a/Shared/alerts/ViewedAlertsController.cpp
+++ b/Shared/alerts/ViewedAlertsController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -51,8 +52,6 @@ namespace Dsa {
 ViewedAlertsController::ViewedAlertsController(QObject* parent /* = nullptr */):
   Toolkit::AbstractTool(parent)
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   AlertListModel* model = AlertListModel::instance();
   if (model)
   {
@@ -61,6 +60,8 @@ ViewedAlertsController::ViewedAlertsController(QObject* parent /* = nullptr */):
     connect(model, &AlertListModel::rowsRemoved, this, &ViewedAlertsController::handleDataChanged);
     emit unviewedCountChanged();
   }
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!
@@ -126,7 +127,6 @@ int ViewedAlertsController::unviewedCount() const
 
   return m_cachedCount;
 }
-
 
 } // Dsa
 

--- a/Shared/analysis/AnalysisListController.cpp
+++ b/Shared/analysis/AnalysisListController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -58,8 +59,6 @@ AnalysisListController::AnalysisListController(QObject* parent):
   Toolkit::AbstractTool(parent),
   m_analysisList(new CombinedAnalysisListModel(this))
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   // update the geoView used by the tool as required
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::geoViewChanged, this, [this]()
   {
@@ -67,6 +66,8 @@ AnalysisListController::AnalysisListController(QObject* parent):
   });
 
   onGeoViewChanged(Toolkit::ToolResourceProvider::instance()->geoView());
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/analysis/LineOfSightController.cpp
+++ b/Shared/analysis/LineOfSightController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -98,8 +99,6 @@ LineOfSightController::LineOfSightController(QObject* parent):
   m_overlayNames(new QStringListModel(this)),
   m_lineOfSightOverlay(new AnalysisOverlay(this))
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   // connect to ToolResourceProvider signals
   auto resourecProvider = Toolkit::ToolResourceProvider::instance();
   connect(resourecProvider, &Toolkit::ToolResourceProvider::geoViewChanged, this, [this]()
@@ -113,6 +112,8 @@ LineOfSightController::LineOfSightController(QObject* parent):
 
   onGeoViewChanged(Toolkit::ToolResourceProvider::instance()->geoView());
   onOperationalLayersChanged(Toolkit::ToolResourceProvider::instance()->operationalLayers());
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/analysis/LineOfSightController.cpp
+++ b/Shared/analysis/LineOfSightController.cpp
@@ -110,10 +110,17 @@ LineOfSightController::LineOfSightController(QObject* parent):
     onOperationalLayersChanged(Toolkit::ToolResourceProvider::instance()->operationalLayers());
   });
 
-  onGeoViewChanged(Toolkit::ToolResourceProvider::instance()->geoView());
   onOperationalLayersChanged(Toolkit::ToolResourceProvider::instance()->operationalLayers());
 
+  // this tool must be in the tool manager before adding analyses below
   Toolkit::ToolManager::instance().addTool(this);
+
+  SceneView* sceneView = dynamic_cast<SceneView*>(Toolkit::ToolResourceProvider::instance()->geoView());
+  if (sceneView)
+  {
+    m_geoView = sceneView;
+    sceneView->analysisOverlays()->append(m_lineOfSightOverlay);
+  }
 }
 
 /*!

--- a/Shared/analysis/ViewshedController.cpp
+++ b/Shared/analysis/ViewshedController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -82,8 +83,6 @@ ViewshedController::ViewshedController(QObject* parent) :
   m_analysisOverlay(new AnalysisOverlay(this)),
   m_viewsheds(new ViewshedListModel(this))
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::geoViewChanged, this, [this]
   {
     setSceneView(dynamic_cast<SceneView*>(Toolkit::ToolResourceProvider::instance()->geoView()));
@@ -108,6 +107,8 @@ ViewshedController::ViewshedController(QObject* parent) :
       emit locationDisplayViewshedActiveChanged();
     }
   });
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/analysis/ViewshedController.cpp
+++ b/Shared/analysis/ViewshedController.cpp
@@ -90,10 +90,6 @@ ViewshedController::ViewshedController(QObject* parent) :
 
   connectMouseSignals();
 
-  auto sceneView = dynamic_cast<SceneView*>(Toolkit::ToolResourceProvider::instance()->geoView());
-  if (sceneView)
-    setSceneView(sceneView);
-
   connect(m_viewsheds, &ViewshedListModel::viewshedRemoved, this, [this](Viewshed360* viewshed)
   {
     std::unique_ptr<Viewshed360> viewshedPtr(viewshed);
@@ -108,7 +104,15 @@ ViewshedController::ViewshedController(QObject* parent) :
     }
   });
 
+  // this tool must be in the tool manager before adding analyses below
   Toolkit::ToolManager::instance().addTool(this);
+
+  auto sceneView = dynamic_cast<SceneView*>(Toolkit::ToolResourceProvider::instance()->geoView());
+  if (sceneView)
+  {
+    m_sceneView = sceneView;
+    m_sceneView->analysisOverlays()->append(m_analysisOverlay);
+  }
 }
 
 /*!

--- a/Shared/markup/MarkupBroadcast.cpp
+++ b/Shared/markup/MarkupBroadcast.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -61,8 +62,6 @@ MarkupBroadcast::MarkupBroadcast(QObject *parent) :
   m_dataSender(new DataSender(parent)),
   m_dataListener(new DataListener(parent))
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   connect(m_dataListener, &DataListener::dataReceived, this, [this](const QByteArray& data)
   {
     QJsonDocument markupJson = QJsonDocument::fromJson(data);
@@ -92,6 +91,8 @@ MarkupBroadcast::MarkupBroadcast(QObject *parent) :
         emit this->markupReceived(markupFileName, sharedBy);
     }
   });
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/markup/MarkupController.cpp
+++ b/Shared/markup/MarkupController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -67,7 +68,6 @@ MarkupController::MarkupController(QObject* parent):
   AbstractSketchTool(parent),
   m_markupBroadcast(new MarkupBroadcast(parent))
 {
-  Toolkit::ToolManager::instance().addTool(this);
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::geoViewChanged, this, &MarkupController::updateGeoView);
 
   updateGeoView();
@@ -82,6 +82,8 @@ MarkupController::MarkupController(QObject* parent):
   {
     emit this->markupSent(fileName);
   });
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/messages/MessageFeedsController.cpp
+++ b/Shared/messages/MessageFeedsController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -66,12 +67,12 @@ MessageFeedsController::MessageFeedsController(QObject* parent) :
   m_messageFeeds(new MessageFeedListModel(this)),
   m_locationBroadcast(new LocationBroadcast(this))
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   connect(Toolkit::ToolResourceProvider::instance(), &Toolkit::ToolResourceProvider::geoViewChanged, this, [this]
   {
     setGeoView(Toolkit::ToolResourceProvider::instance()->geoView());
   });
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!

--- a/Shared/messages/ObservationReportController.cpp
+++ b/Shared/messages/ObservationReportController.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -60,8 +61,6 @@ ObservationReportController::ObservationReportController(QObject* parent):
   m_observedBy(QHostInfo::localHostName()),
   m_highlighter(new PointHighlighter(this))
 {
-  Toolkit::ToolManager::instance().addTool(this);
-
   // connect to ToolResourceProvider signals
   auto resourceProvider = Toolkit::ToolResourceProvider::instance();
   connect(resourceProvider, &Toolkit::ToolResourceProvider::geoViewChanged, this, [this]()
@@ -72,6 +71,8 @@ ObservationReportController::ObservationReportController(QObject* parent):
 
   connect(this, &ObservationReportController::activeChanged, this, &ObservationReportController::onUpdateControlPointHightlight);
   connect(this, &ObservationReportController::controlPointChanged, this, &ObservationReportController::onUpdateControlPointHightlight);
+
+  Toolkit::ToolManager::instance().addTool(this);
 }
 
 /*!
@@ -79,7 +80,6 @@ ObservationReportController::ObservationReportController(QObject* parent):
  */
 ObservationReportController::~ObservationReportController()
 {
-
 }
 
 /*!


### PR DESCRIPTION
Assigned to @ldanzinger.

@michael-tims and @ldanzinger both to review.

Some recent [DSA](https://github.com/Esri/dynamic-situational-awareness-qt/pull/283) changes along with recent [toolkit](https://github.com/Esri/arcgis-runtime-toolkit-qt/pull/299) changes led to this issue, where the default elevation source isn't added at startup anymore.

Due to the timing changes at startup, it's now necessary to make sure the tools are setup before adding them to the tool manager. Once they're added to the tool manager, that can lead to callbacks executing which assume tools exist and are setup. There are two small exceptions and those are noted in the changes.
