### PR TITLE
DSA:

### DIFF
--- a/Shared/ContextMenuController.cpp
+++ b/Shared/ContextMenuController.cpp
@@ -28,6 +28,7 @@
 #include "LayerResultsManager.h"
 #include "LineOfSightController.h"
 #include "ViewshedController.h"
+#include "GeoElementUtils.h"
 
 // toolkit headers
 #include "CoordinateConversionController.h"
@@ -210,8 +211,8 @@ void ContextMenuController::onIdentifyLayersCompleted(const QUuid& taskId, const
       continue;
 
     auto geoElements = res->geoElements();
-    for(GeoElement* geoElement : qAsConst(geoElements))
-      geoElement->setParent(this); // set the GeoElements to be managed by the tool
+    // set the GeoElements to be managed by the tool
+    GeoElementUtils::setParent(geoElements, this);
 
     // add the geoElements to the context hash using the layer name as the key
     m_contextFeatures.insert(res->layerContent()->name(), geoElements);
@@ -252,7 +253,7 @@ void ContextMenuController::onIdentifyGraphicsOverlaysCompleted(const QUuid& tas
     for(; gIt != gEnd; ++gIt)
     {
       GeoElement* geoElement = *gIt;
-      geoElement->setParent(this); // set the GeoElements to be managed by the tool
+      GeoElementUtils::setParent(geoElement, this); // set the GeoElements to be managed by the tool
       geoElements.append(geoElement);
     }
 

--- a/Shared/GeometryQuadtree.cpp
+++ b/Shared/GeometryQuadtree.cpp
@@ -277,7 +277,7 @@ int GeometryQuadtree::handleNewGeoElement(GeoElement* geoElement)
   if (!geoElement)
     return -1;
 
-  GeoElementSignaler* signaler = new GeoElementSignaler(geoElement, this);
+  GeoElementSignaler* signaler = new GeoElementSignaler(geoElement, GeoElementUtils::toQObject(geoElement));
 
   m_elementStorage.insert(m_nextKey, signaler);
   const int insertedKey = m_nextKey;

--- a/Shared/GeometryQuadtree.cpp
+++ b/Shared/GeometryQuadtree.cpp
@@ -153,7 +153,7 @@ QList<Geometry> GeometryQuadtree::candidateIntersections(const Envelope& extent)
     {
       GeoElementSignaler* element = findIt.value();
       if (element)
-        results.push_back(element->m_geoElement->geometry());
+        results.push_back(element->geoElement()->geometry());
     }
   }
 
@@ -184,7 +184,7 @@ QList<Geometry> GeometryQuadtree::candidateIntersections(const Point& location) 
     {
       GeoElementSignaler* element = findIt.value();
       if (element)
-        results.push_back(element->m_geoElement->geometry());
+        results.push_back(element->geoElement()->geometry());
     }
   }
 
@@ -211,7 +211,7 @@ void GeometryQuadtree::buildTree(const Envelope& extent)
     if (!element)
       continue;
 
-    const Geometry wgs84 = GeometryEngine::project(element->m_geoElement->geometry(), SpatialReference::wgs84());
+    const Geometry wgs84 = GeometryEngine::project(element->geoElement()->geometry(), SpatialReference::wgs84());
     m_tree->assign(wgs84.extent(), it.key(), m_maxLevels);
   }
 
@@ -230,7 +230,7 @@ void GeometryQuadtree::handleGeometryChange(int changedId)
   if (!changedElement)
     return;
 
-  const Geometry wgs84Geom = GeometryEngine::project(changedElement->m_geoElement->geometry(), SpatialReference::wgs84());
+  const Geometry wgs84Geom = GeometryEngine::project(changedElement->geoElement()->geometry(), SpatialReference::wgs84());
   const Envelope wgs84Extent = wgs84Geom.extent();
 
   // if the extent of the changed geom is the same or smaller than the existing tree, it can still be used
@@ -254,10 +254,10 @@ void GeometryQuadtree::handleGeometryChange(int changedId)
       if (!element)
         continue;
 
-      if (element->m_geoElement->geometry().isEmpty())
+      if (element->geoElement()->geometry().isEmpty())
         continue;
 
-      allGeom.append(GeometryEngine::project(element->m_geoElement->geometry(), SpatialReference::wgs84()));
+      allGeom.append(GeometryEngine::project(element->geoElement()->geometry(), SpatialReference::wgs84()));
     }
 
     const Geometry newExtent = GeometryEngine::combineExtents(allGeom);

--- a/Shared/GeometryQuadtree.h
+++ b/Shared/GeometryQuadtree.h
@@ -36,6 +36,8 @@ class Point;
 
 namespace Dsa {
 
+class GeoElementSignaler;
+
 class GeometryQuadtree : public QObject
 {
   Q_OBJECT
@@ -65,7 +67,7 @@ private:
 
   int m_maxLevels;
   std::unique_ptr<QuadTree> m_tree;
-  QHash<int, Esri::ArcGISRuntime::GeoElement*> m_elementStorage;
+  QHash<int, GeoElementSignaler*> m_elementStorage;
   int m_nextKey = 0;
 };
 

--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -729,7 +729,7 @@ void AlertConditionsController::onIdentifyLayersCompleted(const QUuid& taskId, Q
       if (!atts)
         return;
 
-      Feature* feature = qobject_cast<Feature*>(geoElement);
+      Feature* feature = dynamic_cast<Feature*>(geoElement);
       if (!feature)
         continue;
 

--- a/Shared/alerts/AlertTarget.cpp
+++ b/Shared/alerts/AlertTarget.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -36,7 +37,6 @@ namespace Dsa {
 AlertTarget::AlertTarget(QObject* parent):
   QObject(parent)
 {
-
 }
 
 /*!

--- a/Shared/alerts/GeoElementAlertTarget.cpp
+++ b/Shared/alerts/GeoElementAlertTarget.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2018 Esri
  *
@@ -18,6 +19,8 @@
 #include "pch.hpp"
 
 #include "GeoElementAlertTarget.h"
+
+#include "GeoElementUtils.h"
 
 // C++ API headers
 #include "GeoElement.h"
@@ -43,10 +46,10 @@ namespace Dsa {
   \brief Constructor taking an \l Esri::ArcGISRuntime::GeoElement (\a geoElement).
  */
 GeoElementAlertTarget::GeoElementAlertTarget(GeoElement* geoElement):
-  AlertTarget(geoElement),
-  m_geoElement(geoElement)
+  AlertTarget(GeoElementUtils::toQObject(geoElement)),
+  m_geoElementSignaler(new GeoElementSignaler(geoElement, this))
 {
-  connect(m_geoElement, &GeoElement::geometryChanged, this, &GeoElementAlertTarget::dataChanged);
+  connect(m_geoElementSignaler, &GeoElementSignaler::geometryChanged, this, &GeoElementAlertTarget::dataChanged);
 }
 
 /*!
@@ -54,7 +57,6 @@ GeoElementAlertTarget::GeoElementAlertTarget(GeoElement* geoElement):
  */
 GeoElementAlertTarget::~GeoElementAlertTarget()
 {
-
 }
 
 /*!
@@ -64,7 +66,7 @@ GeoElementAlertTarget::~GeoElementAlertTarget()
  */
 QList<Geometry> GeoElementAlertTarget::targetGeometries(const Envelope&) const
 {
-  return QList<Geometry>{m_geoElement->geometry()};
+  return QList<Geometry>{m_geoElementSignaler->m_geoElement->geometry()};
 }
 
 /*!

--- a/Shared/alerts/GeoElementAlertTarget.cpp
+++ b/Shared/alerts/GeoElementAlertTarget.cpp
@@ -66,7 +66,7 @@ GeoElementAlertTarget::~GeoElementAlertTarget()
  */
 QList<Geometry> GeoElementAlertTarget::targetGeometries(const Envelope&) const
 {
-  return QList<Geometry>{m_geoElementSignaler->m_geoElement->geometry()};
+  return QList<Geometry>{m_geoElementSignaler->geoElement()->geometry()};
 }
 
 /*!

--- a/Shared/analysis/GeoElementViewshed360.cpp
+++ b/Shared/analysis/GeoElementViewshed360.cpp
@@ -20,6 +20,8 @@
 
 #include "GeoElementViewshed360.h"
 
+#include "GeoElementUtils.h"
+
 // C++ API headers
 #include "AnalysisOverlay.h"
 #include "AttributeListModel.h"
@@ -62,7 +64,7 @@ constexpr double c_defaultOffsetZ = 5.0;
 GeoElementViewshed360::GeoElementViewshed360(GeoElement* geoElement, AnalysisOverlay* analysisOverlay,
                                              const QString& headingAttribute, const QString& pitchAttribute, QObject* parent) :
   Viewshed360(new GeoElementViewshed(geoElement, c_defaultHorizontalAngle, c_defaultVerticalAngle, c_defaultMinDistance, c_defaultMaxDistance, 0.0, 0.0, parent), analysisOverlay, parent),
-  m_geoElement(geoElement),
+  m_geoElementSignaler(new GeoElementSignaler(geoElement, GeoElementUtils::toQObject(geoElement))),
   m_headingAttribute(headingAttribute),
   m_pitchAttribute(pitchAttribute)
 {
@@ -80,7 +82,7 @@ GeoElementViewshed360::~GeoElementViewshed360()
  */
 GeoElement* GeoElementViewshed360::geoElement() const
 {
-  return m_geoElement.data();
+  return m_geoElementSignaler.isNull() ? nullptr : m_geoElementSignaler.data()->m_geoElement;
 }
 
 /*!
@@ -93,10 +95,10 @@ double GeoElementViewshed360::heading() const
   if (m_headingAttribute.isEmpty())
     return static_cast<GeoElementViewshed*>(viewshed())->headingOffset();
 
-  if (m_geoElement.isNull())
+  if (m_geoElementSignaler.isNull())
     return NAN;
 
-  return m_geoElement->attributes()->attributeValue(m_headingAttribute).toDouble();
+  return m_geoElementSignaler->m_geoElement->attributes()->attributeValue(m_headingAttribute).toDouble();
 }
 
 /*!
@@ -115,10 +117,10 @@ void GeoElementViewshed360::setHeading(double heading)
   }
   else
   {
-    if (m_geoElement.isNull())
+    if (m_geoElementSignaler.isNull())
       return;
 
-    auto attributes = m_geoElement->attributes();
+    auto attributes = m_geoElementSignaler->m_geoElement->attributes();
     if (attributes->attributeValue(m_headingAttribute).toDouble() == heading)
       return;
 
@@ -141,10 +143,10 @@ double GeoElementViewshed360::pitch() const
   if (m_pitchAttribute.isEmpty())
     return static_cast<GeoElementViewshed*>(viewshed())->pitchOffset();
 
-  if (m_geoElement.isNull())
+  if (m_geoElementSignaler.isNull())
     return NAN;
 
-  return m_geoElement->attributes()->attributeValue(m_pitchAttribute).toDouble();
+  return m_geoElementSignaler->m_geoElement->attributes()->attributeValue(m_pitchAttribute).toDouble();
 }
 
 /*!
@@ -163,10 +165,10 @@ void GeoElementViewshed360::setPitch(double pitch)
   }
   else
   {
-    if (m_geoElement.isNull())
+    if (m_geoElementSignaler.isNull())
       return;
 
-    auto attributes = m_geoElement->attributes();
+    auto attributes = m_geoElementSignaler->m_geoElement->attributes();
     if (attributes->attributeValue(m_pitchAttribute).toDouble() == pitch)
       return;
 

--- a/Shared/analysis/GeoElementViewshed360.cpp
+++ b/Shared/analysis/GeoElementViewshed360.cpp
@@ -82,7 +82,7 @@ GeoElementViewshed360::~GeoElementViewshed360()
  */
 GeoElement* GeoElementViewshed360::geoElement() const
 {
-  return m_geoElementSignaler.isNull() ? nullptr : m_geoElementSignaler.data()->m_geoElement;
+  return m_geoElementSignaler.isNull() ? nullptr : m_geoElementSignaler.data()->geoElement();
 }
 
 /*!
@@ -98,7 +98,7 @@ double GeoElementViewshed360::heading() const
   if (m_geoElementSignaler.isNull())
     return NAN;
 
-  return m_geoElementSignaler->m_geoElement->attributes()->attributeValue(m_headingAttribute).toDouble();
+  return m_geoElementSignaler->geoElement()->attributes()->attributeValue(m_headingAttribute).toDouble();
 }
 
 /*!
@@ -120,7 +120,7 @@ void GeoElementViewshed360::setHeading(double heading)
     if (m_geoElementSignaler.isNull())
       return;
 
-    auto attributes = m_geoElementSignaler->m_geoElement->attributes();
+    auto attributes = m_geoElementSignaler->geoElement()->attributes();
     if (attributes->attributeValue(m_headingAttribute).toDouble() == heading)
       return;
 
@@ -146,7 +146,7 @@ double GeoElementViewshed360::pitch() const
   if (m_geoElementSignaler.isNull())
     return NAN;
 
-  return m_geoElementSignaler->m_geoElement->attributes()->attributeValue(m_pitchAttribute).toDouble();
+  return m_geoElementSignaler->geoElement()->attributes()->attributeValue(m_pitchAttribute).toDouble();
 }
 
 /*!
@@ -168,7 +168,7 @@ void GeoElementViewshed360::setPitch(double pitch)
     if (m_geoElementSignaler.isNull())
       return;
 
-    auto attributes = m_geoElementSignaler->m_geoElement->attributes();
+    auto attributes = m_geoElementSignaler->geoElement()->attributes();
     if (attributes->attributeValue(m_pitchAttribute).toDouble() == pitch)
       return;
 

--- a/Shared/analysis/GeoElementViewshed360.h
+++ b/Shared/analysis/GeoElementViewshed360.h
@@ -28,6 +28,7 @@ namespace Esri {
 
 namespace Dsa {
 
+class GeoElementSignaler;
 class GeoElementViewshed360 : public Viewshed360
 {
   Q_OBJECT
@@ -59,7 +60,7 @@ private:
   Q_DISABLE_COPY(GeoElementViewshed360)
   GeoElementViewshed360() = delete;
 
-  QPointer<Esri::ArcGISRuntime::GeoElement> m_geoElement;
+  QPointer<GeoElementSignaler> m_geoElementSignaler;
   QString m_headingAttribute;
   QString m_pitchAttribute;
 };

--- a/Shared/analysis/ViewshedController.cpp
+++ b/Shared/analysis/ViewshedController.cpp
@@ -28,6 +28,7 @@
 #include "LocationDisplay3d.h"
 #include "LocationViewshed360.h"
 #include "ViewshedListModel.h"
+#include "GeoElementUtils.h"
 
 // toolkit headers
 #include "ToolManager.h"
@@ -336,8 +337,8 @@ void ViewshedController::addGeoElementViewshed360(GeoElement* geoElement)
   auto geoElementViewshed360 = new GeoElementViewshed360(geoElement, m_analysisOverlay, QString(), QString(), this);
   s_viewshedCount++;
   geoElementViewshed360->setName(QString("Viewshed %1").arg(QString::number(s_viewshedCount)));
-  if (!geoElement->parent())
-    geoElement->setParent(geoElementViewshed360);
+  if (!GeoElementUtils::toQObject(geoElement)->parent())
+    GeoElementUtils::setParent(geoElement, geoElementViewshed360);
 
   geoElementViewshed360->setOffsetZ(c_defaultOffsetZ);
   m_analysisOverlay->analyses()->append(geoElementViewshed360->viewshed());
@@ -781,7 +782,7 @@ void ViewshedController::disconnectActiveViewshedSignals()
 {
   if (!m_activeViewshedConns.isEmpty())
   {
-    for (auto conn : m_activeViewshedConns)
+    for (const auto& conn : qAsConst(m_activeViewshedConns))
     {
       disconnect(conn);
     }

--- a/Shared/utilities/GeoElementUtils.cpp
+++ b/Shared/utilities/GeoElementUtils.cpp
@@ -96,10 +96,10 @@ GeoElement* GeoElementSignaler::geoElement() const
 }
 
 /*!
-  \fn void Dsa::GeoElementUtils::setParent(const QList<Esri::ArcGISRuntime::GeoElement*> geoElements, QObject* parent)
+  \fn void Dsa::GeoElementUtils::setParent(const QList<Esri::ArcGISRuntime::GeoElement*>& geoElements, QObject* parent)
   \brief Allows the \a parent to be applied to all the \a geoElements.
  */
-void GeoElementUtils::setParent(const QList<GeoElement*> geoElements, QObject* parent)
+void GeoElementUtils::setParent(const QList<GeoElement*>& geoElements, QObject* parent)
 {
   if (geoElements.isEmpty())
     return;

--- a/Shared/utilities/GeoElementUtils.cpp
+++ b/Shared/utilities/GeoElementUtils.cpp
@@ -21,12 +21,14 @@
 #include "GeoElementUtils.h"
 
 // C++ API headers
-#include "GeoElement.h"
-#include "Feature.h"
-#include "Graphic.h"
 #include "EncFeature.h"
-#include "WmsFeature.h"
+#include "Feature.h"
+#include "GeoElement.h"
+#include "Graphic.h"
 #include "KmlPlacemark.h"
+#include "WmsFeature.h"
+
+#include <QDebug>
 
 using namespace Esri::ArcGISRuntime;
 
@@ -74,12 +76,24 @@ GeoElementSignaler::GeoElementSignaler(GeoElement* geoElement, QObject* parent) 
     connect(static_cast<WmsFeature*>(m_geoElement), &WmsFeature::geometryChanged,
             this, &GeoElementSignaler::geometryChanged);
   }
+  else
+  {
+    qWarning() << Q_FUNC_INFO << "Unhandled GeoElement type";
+  }
 }
 
 /*!
   \brief Destructor.
  */
 GeoElementSignaler::~GeoElementSignaler() = default;
+
+/*!
+  \brief Returns the managed GeoElement.
+ */
+GeoElement* GeoElementSignaler::geoElement() const
+{
+  return m_geoElement;
+}
 
 /*!
   \fn void Dsa::GeoElementUtils::setParent(const QList<Esri::ArcGISRuntime::GeoElement*> geoElements, QObject* parent)
@@ -98,7 +112,7 @@ void GeoElementUtils::setParent(const QList<Esri::ArcGISRuntime::GeoElement*> ge
 
 /*!
   \fn void Dsa::GeoElementUtils::setParent(Esri::ArcGISRuntime::GeoElement* geoElement, QObject* parent)
-  \brief Allows the \a parent to be applied to \a geoElement.
+  \brief Allows the \a parent to be applied to the \a geoElement.
  */
 void GeoElementUtils::setParent(Esri::ArcGISRuntime::GeoElement* geoElement, QObject* parent)
 {
@@ -128,6 +142,8 @@ QObject* GeoElementUtils::toQObject(Esri::ArcGISRuntime::GeoElement* geoElement)
 
   if (dynamic_cast<WmsFeature*>(geoElement))
     return static_cast<WmsFeature*>(geoElement);
+
+  qWarning() << Q_FUNC_INFO << "Unhandled GeoElement type";
 
   return nullptr;
 }

--- a/Shared/utilities/GeoElementUtils.cpp
+++ b/Shared/utilities/GeoElementUtils.cpp
@@ -1,0 +1,135 @@
+
+/*******************************************************************************
+ *  Copyright 2012-2018 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+
+// PCH header
+#include "pch.hpp"
+
+#include "GeoElementUtils.h"
+
+// C++ API headers
+#include "GeoElement.h"
+#include "Feature.h"
+#include "Graphic.h"
+#include "EncFeature.h"
+#include "WmsFeature.h"
+#include "KmlPlacemark.h"
+
+using namespace Esri::ArcGISRuntime;
+
+namespace Dsa {
+
+/*!
+  \class Dsa::GeoElementSignaler
+  \brief A lightweight class that wraps a GeoElement and provides the geometryChanged signal.
+
+  This object does not take ownership of the GeoElement. You can choose to do that
+  by passing in the managed geoElement as the parent.
+
+  \sa Dsa::GeoElementUtils::toQObject
+ */
+
+/*!
+  \brief Constructor that takes a \a geoElement and an optional \a parent.
+ */
+GeoElementSignaler::GeoElementSignaler(GeoElement* geoElement, QObject* parent) :
+  QObject(parent),
+  m_geoElement(geoElement)
+{
+  if (dynamic_cast<Feature*>(m_geoElement))
+  {
+    connect(static_cast<Feature*>(m_geoElement), &Feature::geometryChanged,
+            this, &GeoElementSignaler::geometryChanged);
+  }
+  else if (dynamic_cast<Graphic*>(m_geoElement))
+  {
+    connect(static_cast<Graphic*>(m_geoElement), &Graphic::geometryChanged,
+            this, &GeoElementSignaler::geometryChanged);
+  }
+  else if (dynamic_cast<KmlPlacemark*>(m_geoElement))
+  {
+    connect(static_cast<KmlPlacemark*>(m_geoElement), &KmlPlacemark::geometryChanged,
+            this, &GeoElementSignaler::geometryChanged);
+  }
+  else if (dynamic_cast<EncFeature*>(m_geoElement))
+  {
+    connect(static_cast<EncFeature*>(m_geoElement), &EncFeature::geometryChanged,
+            this, &GeoElementSignaler::geometryChanged);
+  }
+  else if (dynamic_cast<WmsFeature*>(m_geoElement))
+  {
+    connect(static_cast<WmsFeature*>(m_geoElement), &WmsFeature::geometryChanged,
+            this, &GeoElementSignaler::geometryChanged);
+  }
+}
+
+/*!
+  \brief Destructor.
+ */
+GeoElementSignaler::~GeoElementSignaler() = default;
+
+/*!
+  \fn void Dsa::GeoElementUtils::setParent(const QList<Esri::ArcGISRuntime::GeoElement*> geoElements, QObject* parent)
+  \brief Allows the \a parent to be applied to all the \a geoElements.
+ */
+void GeoElementUtils::setParent(const QList<Esri::ArcGISRuntime::GeoElement*> geoElements, QObject* parent)
+{
+  if (geoElements.isEmpty())
+    return;
+
+  for (auto* geoElement : geoElements)
+  {
+    toQObject(geoElement)->setParent(parent);
+  }
+}
+
+/*!
+  \fn void Dsa::GeoElementUtils::setParent(Esri::ArcGISRuntime::GeoElement* geoElement, QObject* parent)
+  \brief Allows the \a parent to be applied to \a geoElement.
+ */
+void GeoElementUtils::setParent(Esri::ArcGISRuntime::GeoElement* geoElement, QObject* parent)
+{
+  if (geoElement)
+  {
+    toQObject(geoElement)->setParent(parent);
+  }
+}
+
+/*!
+  \fn QObject* Dsa::GeoElementUtils::toQObject(Esri::ArcGISRuntime::GeoElement* geoElement)
+  \brief Returns a QObject* from a GeoElement.
+ */
+QObject* GeoElementUtils::toQObject(Esri::ArcGISRuntime::GeoElement* geoElement)
+{
+  if (dynamic_cast<Feature*>(geoElement))
+    return static_cast<Feature*>(geoElement);
+
+  if (dynamic_cast<Graphic*>(geoElement))
+    return static_cast<Graphic*>(geoElement);
+
+  if (dynamic_cast<KmlPlacemark*>(geoElement))
+    return static_cast<KmlPlacemark*>(geoElement);
+
+  if (dynamic_cast<EncFeature*>(geoElement))
+    return static_cast<EncFeature*>(geoElement);
+
+  if (dynamic_cast<WmsFeature*>(geoElement))
+    return static_cast<WmsFeature*>(geoElement);
+
+  return nullptr;
+}
+
+} // Dsa

--- a/Shared/utilities/GeoElementUtils.cpp
+++ b/Shared/utilities/GeoElementUtils.cpp
@@ -99,7 +99,7 @@ GeoElement* GeoElementSignaler::geoElement() const
   \fn void Dsa::GeoElementUtils::setParent(const QList<Esri::ArcGISRuntime::GeoElement*> geoElements, QObject* parent)
   \brief Allows the \a parent to be applied to all the \a geoElements.
  */
-void GeoElementUtils::setParent(const QList<Esri::ArcGISRuntime::GeoElement*> geoElements, QObject* parent)
+void GeoElementUtils::setParent(const QList<GeoElement*> geoElements, QObject* parent)
 {
   if (geoElements.isEmpty())
     return;
@@ -114,7 +114,7 @@ void GeoElementUtils::setParent(const QList<Esri::ArcGISRuntime::GeoElement*> ge
   \fn void Dsa::GeoElementUtils::setParent(Esri::ArcGISRuntime::GeoElement* geoElement, QObject* parent)
   \brief Allows the \a parent to be applied to the \a geoElement.
  */
-void GeoElementUtils::setParent(Esri::ArcGISRuntime::GeoElement* geoElement, QObject* parent)
+void GeoElementUtils::setParent(GeoElement* geoElement, QObject* parent)
 {
   if (geoElement)
   {
@@ -126,7 +126,7 @@ void GeoElementUtils::setParent(Esri::ArcGISRuntime::GeoElement* geoElement, QOb
   \fn QObject* Dsa::GeoElementUtils::toQObject(Esri::ArcGISRuntime::GeoElement* geoElement)
   \brief Returns a QObject* from a GeoElement.
  */
-QObject* GeoElementUtils::toQObject(Esri::ArcGISRuntime::GeoElement* geoElement)
+QObject* GeoElementUtils::toQObject(GeoElement* geoElement)
 {
   if (dynamic_cast<Feature*>(geoElement))
     return static_cast<Feature*>(geoElement);

--- a/Shared/utilities/GeoElementUtils.h
+++ b/Shared/utilities/GeoElementUtils.h
@@ -37,10 +37,13 @@ public:
   GeoElementSignaler(Esri::ArcGISRuntime::GeoElement* geoElement, QObject* parent = nullptr);
   ~GeoElementSignaler();
 
-  Esri::ArcGISRuntime::GeoElement* m_geoElement = nullptr;
+  Esri::ArcGISRuntime::GeoElement* geoElement() const;
 
 signals:
   void geometryChanged();
+
+private:
+  Esri::ArcGISRuntime::GeoElement* m_geoElement = nullptr;
 };
 
 namespace GeoElementUtils

--- a/Shared/utilities/GeoElementUtils.h
+++ b/Shared/utilities/GeoElementUtils.h
@@ -48,7 +48,7 @@ private:
 
 namespace GeoElementUtils
 {
-  void setParent(const QList<Esri::ArcGISRuntime::GeoElement*> geoElements, QObject* parent);
+  void setParent(const QList<Esri::ArcGISRuntime::GeoElement*>& geoElements, QObject* parent);
   void setParent(Esri::ArcGISRuntime::GeoElement* geoElement, QObject* parent);
   QObject* toQObject(Esri::ArcGISRuntime::GeoElement* geoElement);
 }

--- a/Shared/utilities/GeoElementUtils.h
+++ b/Shared/utilities/GeoElementUtils.h
@@ -14,36 +14,42 @@
  *  limitations under the License.
  ******************************************************************************/
 
-#ifndef GEOELEMENTALERTTARGET_H
-#define GEOELEMENTALERTTARGET_H
+#ifndef GEOELEMENTUTILS_H
+#define GEOELEMENTUTILS_H
 
-// example app headers
-#include "AlertTarget.h"
+// Qt headers
+#include <QList>
+#include <QObject>
 
 namespace Esri {
 namespace ArcGISRuntime {
-class GeoElement;
+  class GeoElement;
 }
 }
 
 namespace Dsa {
 
-class GeoElementSignaler;
-class GeoElementAlertTarget : public AlertTarget
+class GeoElementSignaler : public QObject
 {
   Q_OBJECT
 
 public:
-  explicit GeoElementAlertTarget(Esri::ArcGISRuntime::GeoElement* geoElement);
-  ~GeoElementAlertTarget();
+  GeoElementSignaler(Esri::ArcGISRuntime::GeoElement* geoElement, QObject* parent = nullptr);
+  ~GeoElementSignaler();
 
-  QList<Esri::ArcGISRuntime::Geometry> targetGeometries(const Esri::ArcGISRuntime::Envelope& targetArea) const override;
-  QVariant targetValue() const override;
+  Esri::ArcGISRuntime::GeoElement* m_geoElement = nullptr;
 
-private:
-  GeoElementSignaler* m_geoElementSignaler = nullptr;
+signals:
+  void geometryChanged();
 };
+
+namespace GeoElementUtils
+{
+  void setParent(const QList<Esri::ArcGISRuntime::GeoElement*> geoElements, QObject* parent);
+  void setParent(Esri::ArcGISRuntime::GeoElement* geoElement, QObject* parent);
+  QObject* toQObject(Esri::ArcGISRuntime::GeoElement* geoElement);
+}
 
 } // Dsa
 
-#endif // GEOELEMENTALERTTARGET_H
+#endif // GEOELEMENTUTILS_H


### PR DESCRIPTION
Mitigate the GeoElement base class changes.
Provide helpers and a wrapper class that provide the
now-missing signal on GeoElement.

@michael-tims @lsmallwood @ldanzinger please review. I've added a new GeoElementUtils set of helpers and a wrapper class to minimize the code changes needed in the DSA app. Mostly what we need to do and can't do anymore is set the parent and connect directly to a GeoElement's signals.

Blocked for now, requires changes not in the Runtime SDK yet.