### PR TITLE
Don't increment the target index if the operational layer is invalid …

### DIFF
--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -1053,7 +1053,6 @@ AlertTarget* AlertConditionsController::targetFromItemIdAndIndex(int itemId, int
     const int opLayersCount = operationalLayers->rowCount();
     for (int i = 0; i < opLayersCount; ++i)
     {
-      currIndex++;
       Layer* layer = operationalLayers->at(i);
       if (!layer)
         continue;
@@ -1061,6 +1060,8 @@ AlertTarget* AlertConditionsController::targetFromItemIdAndIndex(int itemId, int
       FeatureLayer* featLayer = qobject_cast<FeatureLayer*>(layer);
       if (!featLayer)
         continue;
+
+      currIndex++;
 
       if (currIndex == targetOverlayIndex)
       {


### PR DESCRIPTION
…(e.g. a raster or a terrain model) (#289)

v.next cherry pick of https://github.com/Esri/dynamic-situational-awareness-qt/pull/289

Already approved and merged to master. Just keeping v.next in sync. @ldanzinger please review.