### PR TITLE
Use new SelectionProperties API

### DIFF
--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -125,6 +125,9 @@ void DsaController::init(GeoView* geoView)
   Toolkit::ToolResourceProvider::instance()->setScene(m_scene);
   Toolkit::ToolResourceProvider::instance()->setGeoView(geoView);
 
+  // set the selection color for graphics and features
+  geoView->setSelectionProperties(SelectionProperties(Qt::red));
+
   m_cacheManager = new LayerCacheManager(this);
 
   // connect all tool signals

--- a/Shared/messages/MessagesOverlay.cpp
+++ b/Shared/messages/MessagesOverlay.cpp
@@ -66,7 +66,6 @@ MessagesOverlay::MessagesOverlay(GeoView* geoView, Renderer* renderer, const QSt
   m_graphicsOverlay->setRenderingMode(GraphicsRenderingMode::Dynamic);
   m_graphicsOverlay->setSceneProperties(LayerSceneProperties(m_surfacePlacement));
   m_graphicsOverlay->setRenderer(m_renderer);
-  m_graphicsOverlay->setSelectionColor(Qt::red);
   m_geoView->graphicsOverlays()->append(m_graphicsOverlay);
 }
 


### PR DESCRIPTION
Assign to @JamesMBallard 

No issue, but we should fix this now.  The existing `setSelectionColor` on GraphicsOverlay is deprecated at 100.4 . Replacing with the new SelectionProperties method on GeoView.  I've tested this on iOS.