### PR TITLE
Fix compiler warnings:

### DIFF
--- a/Shared/AddLocalDataController.cpp
+++ b/Shared/AddLocalDataController.cpp
@@ -412,7 +412,7 @@ void AddLocalDataController::createFeatureLayerGeodatabase(const QString& path)
 
       connect(featureLayer, &FeatureLayer::errorOccurred, this, &AddLocalDataController::errorOccurred);
 
-      connect(featureLayer, &FeatureLayer::doneLoading, this, [this, featureLayer](Error loadError)
+      connect(featureLayer, &FeatureLayer::doneLoading, this, [featureLayer](Error loadError)
       {
         if (!loadError.isEmpty())
           return;
@@ -458,7 +458,7 @@ void AddLocalDataController::createFeatureLayerGeodatabaseWithId(const QString& 
     featureLayer->setVisible(visible);
     connect(featureLayer, &FeatureLayer::errorOccurred, this, &AddLocalDataController::errorOccurred);
 
-    connect(featureLayer, &FeatureLayer::doneLoading, this, [this, featureLayer](Error loadError)
+    connect(featureLayer, &FeatureLayer::doneLoading, this, [featureLayer](Error loadError)
     {
       if (!loadError.isEmpty())
         return;
@@ -513,7 +513,7 @@ void AddLocalDataController::createFeatureLayerGeoPackage(const QString& path, i
     featureLayer->setVisible(visible);
     connect(featureLayer, &FeatureLayer::errorOccurred, this, &AddLocalDataController::errorOccurred);
 
-    connect(featureLayer, &FeatureLayer::doneLoading, this, [this, featureLayer](Error loadError)
+    connect(featureLayer, &FeatureLayer::doneLoading, this, [featureLayer](Error loadError)
     {
       if (!loadError.isEmpty())
         return;
@@ -608,7 +608,7 @@ void AddLocalDataController::createLayerGeoPackage(const QString& path)
       FeatureLayer* featureLayer = new FeatureLayer(table, this);
       connect(featureLayer, &FeatureLayer::errorOccurred, this, &AddLocalDataController::errorOccurred);
 
-      connect(featureLayer, &FeatureLayer::doneLoading, this, [this, featureLayer](Error loadError)
+      connect(featureLayer, &FeatureLayer::doneLoading, this, [featureLayer](Error loadError)
       {
         if (!loadError.isEmpty())
           return;
@@ -656,7 +656,7 @@ void AddLocalDataController::createFeatureLayerShapefile(const QString& path, in
   featureLayer->setVisible(visible);
   connect(featureLayer, &FeatureLayer::errorOccurred, this, &AddLocalDataController::errorOccurred);
 
-  connect(featureLayer, &FeatureLayer::doneLoading, this, [this, featureLayer](Error loadError)
+  connect(featureLayer, &FeatureLayer::doneLoading, this, [featureLayer](Error loadError)
   {
     if (!loadError.isEmpty())
       return;

--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -1144,13 +1144,13 @@ AlertTarget* AlertConditionsController::targetFromFeatureLayer(FeatureLayer* fea
   QEventLoop loop;
   tab->queryFeatures(qp);
 
-  connect(tab, &FeatureTable::errorOccurred, this, [this, &loop](Error)
+  connect(tab, &FeatureTable::errorOccurred, this, [&loop](Error)
   {
     loop.quit();
   });
 
   Feature* feature = nullptr;
-  auto connection = loop.connect(tab, &FeatureTable::queryFeaturesCompleted, this, [this, &loop, &feature](QUuid, FeatureQueryResult* featureQueryResult)
+  auto connection = loop.connect(tab, &FeatureTable::queryFeaturesCompleted, this, [&loop, &feature](QUuid, FeatureQueryResult* featureQueryResult)
   {
     loop.quit();
 

--- a/Shared/analysis/GeoElementViewshed360.cpp
+++ b/Shared/analysis/GeoElementViewshed360.cpp
@@ -34,12 +34,10 @@ using namespace Esri::ArcGISRuntime;
 
 namespace Dsa {
 
-constexpr double c_defaultPitch = 0.0;
 constexpr double c_defaultHorizontalAngle = 360.0;
 constexpr double c_defaultVerticalAngle = 90.0;
 constexpr double c_defaultMinDistance = 0.0;
 constexpr double c_defaultMaxDistance = 500.0;
-constexpr double c_defaultOffsetZ = 5.0;
 
 /*!
   \class Dsa::GeoElementViewshed360


### PR DESCRIPTION
- unused this in lambda captures
- unused variables

@michael-tims please review the fixes for some compiler warnings on Mac