### PR TITLE
Revert "The path has changed slightly. This is needed for the quick-start steps."

### DIFF
--- a/Shared/build/resolvelocaltoolkit.pri
+++ b/Shared/build/resolvelocaltoolkit.pri
@@ -19,7 +19,7 @@
 exists($$PWD/../../../../sdk/toolkit/Plugin/CppApi/ArcGISRuntimeToolkit.pri) {
   CppToolkitLocation = $$absolute_path($$PWD/../../../../sdk/toolkit/Plugin/CppApi)
 } else {
-  exists($$PWD/../../../arcgis-runtime-toolkit-qt/Plugin/CppApi/ArcGISRuntimeToolkit.pri) {
-    CppToolkitLocation = $$absolute_path($$PWD/../../../arcgis-runtime-toolkit-qt/Plugin/CppApi)
+  exists($$PWD/../../arcgis-runtime-toolkit-qt/Plugin/CppApi/ArcGISRuntimeToolkit.pri) {
+    CppToolkitLocation = $$absolute_path($$PWD/../../arcgis-runtime-toolkit-qt/Plugin/CppApi)
   }
 }


### PR DESCRIPTION
Reverts Esri/dynamic-situational-awareness-qt#295

Not needed if you actually follow the quick-start steps. The toolkit repo should be cloned inside the DSA repo when both are pulled down locally.