### PR TITLE
Update version to 100.6.

### DIFF
--- a/Handheld/Handheld.pro
+++ b/Handheld/Handheld.pro
@@ -20,7 +20,7 @@ TEMPLATE = app
 QT += core gui opengl network positioning sensors qml quick xml
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.5
+ARCGIS_RUNTIME_VERSION = 100.6
 include($$PWD/../Shared/build/arcgisruntime.pri)
 include($$PWD/../Shared/build/arcgisruntimecpptoolkit.pri)
 

--- a/Shared/build/arcgisruntimecpptoolkit.pri
+++ b/Shared/build/arcgisruntimecpptoolkit.pri
@@ -28,5 +28,5 @@ include($$PWD/resolvelocaltoolkit.pri)
   }
 }
 else {
-  error("Error. Cannot locate ArcGIS Runtime C++ Toolkit PRI file. Toolkit repo must be cloned locally")
+  error("Error. Cannot locate ArcGIS Runtime C++ Toolkit files. Toolkit repo must be cloned locally.")
 }

--- a/Shared/build/arcgisruntimecpptoolkit.pri
+++ b/Shared/build/arcgisruntimecpptoolkit.pri
@@ -28,9 +28,5 @@ include($$PWD/resolvelocaltoolkit.pri)
   }
 }
 else {
-  include($$PWD/resolvesdkinstall.pri)
-  # use the toolkit included with the SDK installation
-  !include($$QtRuntimeSdkPath/sdk/ideintegration/arcgis_runtime_toolkit_cpp.pri) {
-    message("Error. Cannot locate ArcGIS Runtime C++ Toolkit PRI file")
-  }
+  error("Error. Cannot locate ArcGIS Runtime C++ Toolkit PRI file. Toolkit repo must be cloned locally")
 }

--- a/Vehicle/Vehicle.pro
+++ b/Vehicle/Vehicle.pro
@@ -20,7 +20,7 @@ TEMPLATE = app
 QT += core gui opengl network positioning sensors qml quick xml
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.5
+ARCGIS_RUNTIME_VERSION = 100.6
 include($$PWD/../Shared/build/arcgisruntime.pri)
 include($$PWD/../Shared/build/arcgisruntimecpptoolkit.pri)
 


### PR DESCRIPTION
Also drop the toolkit library linking from the setup location.
We now require building the toolkit library directly from the
locally cloned repo.

Assigned to @khajra. Please review.

This is merging to v.next for the next release. We are planning on dropping the C++ Api toolkit library from the setup, so removing the option to search for the one included with the setup.

I will merge this in sync with all related PRs.