### PR TITLE
James/100.7 launch

### DIFF
--- a/Shared/qml/MapToolRow.qml
+++ b/Shared/qml/MapToolRow.qml
@@ -131,25 +131,6 @@ Row {
             name: basemapIcon.toolName
             PropertyChanges {
                 target: basemapIcon
-                selected: true
-            }
-            PropertyChanges {
-                target: tocIcon
-                selected: selected
-            }
-            PropertyChanges {
-                target: coordinateConversionIcon
-                selected: selected
-            }
-            PropertyChanges {
-                target: identifyIcon
-                selected: selected
-            }
-        },
-        State {
-            name: basemapIcon.toolName
-            PropertyChanges {
-                target: basemapIcon
                 selected: selected
             }
             PropertyChanges {


### PR DESCRIPTION
I was receiving errors on duplicate state names. It looks as if the state `basemapIcon.toolName` was referenced twice in this list. Could you verify I have removed the correct one?