### PR TITLE
Updated to 100.8 and fixed 100.8 issues.

### DIFF
--- a/Handheld/Android/AndroidManifest.xml
+++ b/Handheld/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.1" android:versionCode="2" android:installLocation="auto">
+<manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.2" android:versionCode="3" android:installLocation="auto">
     <application android:hardwareAccelerated="true" android:icon="@drawable/icon" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="DSA_H_Qt" android:theme="@android:style/Theme.Holo.Light.NoActionBar">
         <activity android:name="org.qtproject.qt5.android.bindings.QtActivity" android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation" android:screenOrientation="unspecified" android:label="DSA_H_Qt">
             <intent-filter>

--- a/Handheld/Handheld.pro
+++ b/Handheld/Handheld.pro
@@ -20,7 +20,7 @@ TEMPLATE = app
 QT += core gui opengl network positioning sensors qml quick xml
 CONFIG += c++14
 
-ARCGIS_RUNTIME_VERSION = 100.7
+ARCGIS_RUNTIME_VERSION = 100.8
 include($$PWD/../Shared/build/arcgisruntime.pri)
 include($$PWD/../Shared/build/arcgisruntimecpptoolkit.pri)
 

--- a/Handheld/iOS/Info.plist
+++ b/Handheld/iOS/Info.plist
@@ -59,11 +59,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-  <string>1.1.1</string>
+  <string>1.1.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-  <string>1.1.1</string>
+  <string>1.1.2</string>
 	<key>NOTE</key>
 	<string>Built with ArcGIS Runtime SDK for Qt.</string>
 	<key>UIFileSharingEnabled</key>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## 1.1.2
+
+- Updated to use version 100.8 of the ArcGIS Runtime SDK for Qt.
+- Fixed crash on RasterCell identify.
+
 ## 1.1.1
 
 - Updated to use version 100.7 of the ArcGIS Runtime SDK for Qt.

--- a/Shared/utilities/GeoElementUtils.cpp
+++ b/Shared/utilities/GeoElementUtils.cpp
@@ -26,6 +26,7 @@
 #include "GeoElement.h"
 #include "Graphic.h"
 #include "KmlPlacemark.h"
+#include "RasterCell.h"
 #include "WmsFeature.h"
 
 #include <QDebug>
@@ -76,6 +77,11 @@ GeoElementSignaler::GeoElementSignaler(GeoElement* geoElement, QObject* parent) 
     connect(static_cast<WmsFeature*>(m_geoElement), &WmsFeature::geometryChanged,
             this, &GeoElementSignaler::geometryChanged);
   }
+  else if (dynamic_cast<RasterCell*>(m_geoElement))
+  {
+    connect(static_cast<RasterCell*>(m_geoElement), &RasterCell::geometryChanged,
+            this, &GeoElementSignaler::geometryChanged);
+  }
   else
   {
     qWarning() << Q_FUNC_INFO << "Unhandled GeoElement type";
@@ -106,7 +112,9 @@ void GeoElementUtils::setParent(const QList<GeoElement*>& geoElements, QObject* 
 
   for (auto* geoElement : geoElements)
   {
-    toQObject(geoElement)->setParent(parent);
+    auto object = toQObject(geoElement);
+    if (object)
+      object->setParent(parent);
   }
 }
 
@@ -118,7 +126,9 @@ void GeoElementUtils::setParent(GeoElement* geoElement, QObject* parent)
 {
   if (geoElement)
   {
-    toQObject(geoElement)->setParent(parent);
+    auto object = toQObject(geoElement);
+    if (object)
+      object->setParent(parent);
   }
 }
 
@@ -142,6 +152,9 @@ QObject* GeoElementUtils::toQObject(GeoElement* geoElement)
 
   if (dynamic_cast<WmsFeature*>(geoElement))
     return static_cast<WmsFeature*>(geoElement);
+
+  if (dynamic_cast<RasterCell*>(geoElement))
+    return static_cast<RasterCell*>(geoElement);
 
   qWarning() << Q_FUNC_INFO << "Unhandled GeoElement type";
 

--- a/Vehicle/Vehicle.pro
+++ b/Vehicle/Vehicle.pro
@@ -20,7 +20,7 @@ TEMPLATE = app
 QT += core gui opengl network positioning sensors qml quick xml
 CONFIG += c++14
 
-ARCGIS_RUNTIME_VERSION = 100.7
+ARCGIS_RUNTIME_VERSION = 100.8
 include($$PWD/../Shared/build/arcgisruntime.pri)
 include($$PWD/../Shared/build/arcgisruntimecpptoolkit.pri)
 


### PR DESCRIPTION
- Updated to use version 100.8 of the ArcGIS Runtime SDK for Qt.
- Fixed crash on RasterCell identify.

