### PR TITLE
Now targeting Android API level 29.

### DIFF
--- a/Handheld/Android/Android.pri
+++ b/Handheld/Android/Android.pri
@@ -22,5 +22,6 @@ ANDROID_PACKAGE_SOURCE_DIR = $$PWD
 OTHER_FILES +=     $$ANDROID_PACKAGE_SOURCE_DIR/res/drawable-ldpi/icon.png     $$ANDROID_PACKAGE_SOURCE_DIR/res/drawable-mdpi/icon.png     $$ANDROID_PACKAGE_SOURCE_DIR/res/drawable-hdpi/icon.png     $$ANDROID_PACKAGE_SOURCE_DIR/res/drawable-xhdpi/icon.png     $$ANDROID_PACKAGE_SOURCE_DIR/res/drawable-xxhdpi/icon.png
 
 DISTFILES += \
-    $$PWD/AndroidManifest.xml
-
+    $$PWD/AndroidManifest.xml \
+    $$PWD/build.gradle \
+    $$PWD/res/values/libs.xml

--- a/Handheld/Android/AndroidManifest.xml
+++ b/Handheld/Android/AndroidManifest.xml
@@ -1,7 +1,19 @@
 <?xml version="1.0"?>
-<manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.2" android:versionCode="3" android:installLocation="auto">
-    <application android:hardwareAccelerated="true" android:icon="@drawable/icon" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="DSA_H_Qt" android:theme="@android:style/Theme.Holo.Light.NoActionBar">
-        <activity android:name="org.qtproject.qt5.android.bindings.QtActivity" android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation" android:screenOrientation="unspecified" android:label="DSA_H_Qt">
+<manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.3" android:versionCode="4" android:installLocation="auto">
+    <uses-sdk android:minSdkVersion="20" android:targetSdkVersion="29"/>
+
+    <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
+         Remove the comment if you do not require these default permissions. -->
+    <!-- %%INSERT_PERMISSIONS -->
+
+    <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
+         Remove the comment if you do not require these default features. -->
+    <!-- %%INSERT_FEATURES -->
+
+    <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
+
+    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="DSA_H_Qt">
+        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density" android:name="org.qtproject.qt5.android.bindings.QtActivity" android:label="DSA_H_Qt" android:screenOrientation="unspecified" android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -26,11 +38,25 @@
             <meta-data android:name="android.app.load_local_libs" android:value="-- %%INSERT_LOCAL_LIBS%% --"/>
             <meta-data android:name="android.app.load_local_jars" android:value="-- %%INSERT_LOCAL_JARS%% --"/>
             <meta-data android:name="android.app.static_init_classes" android:value="-- %%INSERT_INIT_CLASSES%% --"/>
+            <!-- Used to specify custom system library path to run with local system libs -->
+            <!-- <meta-data android:name="android.app.system_libs_prefix" android:value="/system/lib/"/> -->
             <!--  Messages maps -->
             <meta-data android:value="@string/ministro_not_found_msg" android:name="android.app.ministro_not_found_msg"/>
             <meta-data android:value="@string/ministro_needed_msg" android:name="android.app.ministro_needed_msg"/>
             <meta-data android:value="@string/fatal_error_msg" android:name="android.app.fatal_error_msg"/>
+            <meta-data android:value="@string/unsupported_android_version" android:name="android.app.unsupported_android_version"/>
             <!--  Messages maps -->
+
+            <!-- Splash screen -->
+            <!-- Orientation-specific (portrait/landscape) data is checked first. If not available for current orientation,
+                 then android.app.splash_screen_drawable. For best results, use together with splash_screen_sticky and
+                 use hideSplashScreen() with a fade-out animation from Qt Android Extras to hide the splash screen when you
+                 are done populating your window with content. -->
+            <!-- meta-data android:name="android.app.splash_screen_drawable_portrait" android:resource="@drawable/logo_portrait" / -->
+            <!-- meta-data android:name="android.app.splash_screen_drawable_landscape" android:resource="@drawable/logo_landscape" / -->
+            <!-- meta-data android:name="android.app.splash_screen_drawable" android:resource="@drawable/logo"/ -->
+            <!-- meta-data android:name="android.app.splash_screen_sticky" android:value="true"/ -->
+            <!-- Splash screen -->
 
             <!-- Background running -->
             <!-- Warning: changing this value to true may cause unexpected crashes if the
@@ -46,31 +72,23 @@
 
             <!-- extract android style -->
             <!-- available android:values :
+                * default - In most cases this will be the same as "full", but it can also be something else if needed, e.g., for compatibility reasons
                 * full - useful QWidget & Quick Controls 1 apps
                 * minimal - useful for Quick Controls 2 apps, it is much faster than "full"
                 * none - useful for apps that don't use any of the above Qt modules
                 -->
-            <meta-data android:name="android.app.extract_android_style" android:value="full"/>
+            <meta-data android:name="android.app.extract_android_style" android:value="default"/>
             <!-- extract android style -->
-            <!-- Splash screen -->
-            <meta-data android:name="android.app.splash_screen" android:resource="@layout/splash"/>
-            <!-- Splash screen -->
     </activity>
 
     <!-- For adding service(s) please check: https://wiki.qt.io/AndroidServices -->
 
     </application>
 
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="16"/>
-    <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
-
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.BLUETOOTH"/>
-
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 </manifest>

--- a/Handheld/Android/AndroidManifest.xml
+++ b/Handheld/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.3" android:versionCode="4" android:installLocation="auto">
-    <uses-sdk android:minSdkVersion="20" android:targetSdkVersion="29"/>
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
          Remove the comment if you do not require these default permissions. -->

--- a/Handheld/Android/AndroidManifest.xml
+++ b/Handheld/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.3" android:versionCode="4" android:installLocation="auto">
+<manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.2.0" android:versionCode="4" android:installLocation="auto">
     <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.

--- a/Handheld/Android/build.gradle
+++ b/Handheld/Android/build.gradle
@@ -1,0 +1,57 @@
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.2.0'
+    }
+}
+
+repositories {
+    google()
+    jcenter()
+}
+
+apply plugin: 'com.android.application'
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
+}
+
+android {
+    /*******************************************************
+     * The following variables:
+     * - androidBuildToolsVersion,
+     * - androidCompileSdkVersion
+     * - qt5AndroidDir - holds the path to qt android files
+     *                   needed to build any Qt application
+     *                   on Android.
+     *
+     * are defined in gradle.properties file. This file is
+     * updated by QtCreator and androiddeployqt tools.
+     * Changing them manually might break the compilation!
+     *******************************************************/
+
+    compileSdkVersion androidCompileSdkVersion.toInteger()
+
+    buildToolsVersion '28.0.3'
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = [qt5AndroidDir + '/src', 'src', 'java']
+            aidl.srcDirs = [qt5AndroidDir + '/src', 'src', 'aidl']
+            res.srcDirs = [qt5AndroidDir + '/res', 'res']
+            resources.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            assets.srcDirs = ['assets']
+            jniLibs.srcDirs = ['libs']
+       }
+    }
+
+    lintOptions {
+        abortOnError false
+    }
+}

--- a/Handheld/Android/res/values/libs.xml
+++ b/Handheld/Android/res/values/libs.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <array name="qt_sources">
+        <item>https://download.qt.io/ministro/android/qt5/qt-5.9</item>
+    </array>
+
+    <!-- The following is handled automatically by the deployment tool. It should
+         not be edited manually. -->
+
+    <array name="bundled_libs">
+        <!-- %%INSERT_EXTRA_LIBS%% -->
+    </array>
+
+     <array name="qt_libs">
+         <!-- %%INSERT_QT_LIBS%% -->
+     </array>
+
+    <array name="bundled_in_lib">
+        <!-- %%INSERT_BUNDLED_IN_LIB%% -->
+    </array>
+    <array name="bundled_in_assets">
+        <!-- %%INSERT_BUNDLED_IN_ASSETS%% -->
+    </array>
+
+</resources>

--- a/Handheld/AppInfo.h
+++ b/Handheld/AppInfo.h
@@ -22,7 +22,7 @@
 #define kOrganizationDomain             "esri.com"
 
 #define kApplicationName                "DSA_Handheld_Qt"
-#define kApplicationVersion             "1.1.1"
+#define kApplicationVersion             "1.2.0"
 #define kApplicationDescription         "Dynamic Situational Awareness - Handheld app"
 
 #define kApplicationSourceUrl           "qrc:/qml/main.qml"

--- a/Handheld/main.cpp
+++ b/Handheld/main.cpp
@@ -113,33 +113,33 @@ int main(int argc, char *argv[])
   QSettings::setDefaultFormat(kSettingsFormat);
 
   // Register the map view for QML
-  qmlRegisterType<SceneQuickView>("Esri.ArcGISRuntime.OpenSourceApps.Handheld", 1, 1, "SceneView");
+  qmlRegisterType<SceneQuickView>("Esri.ArcGISRuntime.OpenSourceApps.Handheld", 1, 2, "SceneView");
   qRegisterMetaType<PopupManager*>("PopupManager*");
 
   // Register the Handheld (QQuickItem) for QML
-  qmlRegisterType<Dsa::Handheld::Handheld>("Esri.ArcGISRuntime.OpenSourceApps.Handheld", 1, 1, "Handheld");
-  qmlRegisterType<Dsa::BasemapPickerController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "BasemapPickerController");
-  qmlRegisterType<Dsa::AddLocalDataController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "AddLocalDataController");
-  qmlRegisterType<Dsa::LocationController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "LocationController");
-  qmlRegisterType<Dsa::MessageFeedsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "MessageFeedsController");
-  qmlRegisterType<Dsa::FollowPositionController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "FollowPositionController");
-  qmlRegisterType<Dsa::TableOfContentsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "TableOfContentsController");
-  qmlRegisterType<Dsa::NavigationController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "NavigationController");
-  qmlRegisterType<Dsa::MarkupController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "MarkupController");
-  qmlRegisterType<Dsa::ViewshedController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "ViewshedController");
-  qmlRegisterType<Dsa::OptionsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "OptionsController");
-  qmlRegisterSingletonType<Dsa::Handheld::HandheldStyles>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "DsaStyles", &dsaStylesProvider);
-  qmlRegisterSingletonType<Dsa::DsaResources>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "DsaResources", &dsaResourcesProvider);
-  qmlRegisterType<Dsa::IdentifyController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "IdentifyController");
-  qmlRegisterType<Dsa::AlertListController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "AlertListController");
-  qmlRegisterType<Dsa::ViewedAlertsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "ViewedAlertsController");
-  qmlRegisterType<Dsa::LocationTextController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "LocationTextController");
-  qmlRegisterType<Dsa::AlertConditionsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "AlertConditionsController");
-  qmlRegisterType<Dsa::LineOfSightController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "LineOfSightController");
-  qmlRegisterType<Dsa::ContextMenuController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "ContextMenuController");
-  qmlRegisterType<Dsa::AnalysisListController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "AnalysisListController");
-  qmlRegisterType<Dsa::ObservationReportController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "ObservationReportController");
-  qmlRegisterType<Dsa::OpenMobileScenePackageController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "OpenMobileScenePackageController");
+  qmlRegisterType<Dsa::Handheld::Handheld>("Esri.ArcGISRuntime.OpenSourceApps.Handheld", 1, 2, "Handheld");
+  qmlRegisterType<Dsa::BasemapPickerController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "BasemapPickerController");
+  qmlRegisterType<Dsa::AddLocalDataController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "AddLocalDataController");
+  qmlRegisterType<Dsa::LocationController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "LocationController");
+  qmlRegisterType<Dsa::MessageFeedsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "MessageFeedsController");
+  qmlRegisterType<Dsa::FollowPositionController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "FollowPositionController");
+  qmlRegisterType<Dsa::TableOfContentsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "TableOfContentsController");
+  qmlRegisterType<Dsa::NavigationController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "NavigationController");
+  qmlRegisterType<Dsa::MarkupController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "MarkupController");
+  qmlRegisterType<Dsa::ViewshedController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "ViewshedController");
+  qmlRegisterType<Dsa::OptionsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "OptionsController");
+  qmlRegisterSingletonType<Dsa::Handheld::HandheldStyles>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "DsaStyles", &dsaStylesProvider);
+  qmlRegisterSingletonType<Dsa::DsaResources>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "DsaResources", &dsaResourcesProvider);
+  qmlRegisterType<Dsa::IdentifyController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "IdentifyController");
+  qmlRegisterType<Dsa::AlertListController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "AlertListController");
+  qmlRegisterType<Dsa::ViewedAlertsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "ViewedAlertsController");
+  qmlRegisterType<Dsa::LocationTextController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "LocationTextController");
+  qmlRegisterType<Dsa::AlertConditionsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "AlertConditionsController");
+  qmlRegisterType<Dsa::LineOfSightController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "LineOfSightController");
+  qmlRegisterType<Dsa::ContextMenuController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "ContextMenuController");
+  qmlRegisterType<Dsa::AnalysisListController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "AnalysisListController");
+  qmlRegisterType<Dsa::ObservationReportController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "ObservationReportController");
+  qmlRegisterType<Dsa::OpenMobileScenePackageController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "OpenMobileScenePackageController");
 
   // Register Toolkit Component Types
   ArcGISRuntimeToolkit::registerToolkitTypes();

--- a/Handheld/qml/main.qml
+++ b/Handheld/qml/main.qml
@@ -20,8 +20,8 @@ import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
 import QtQml.Models 2.2
 import QtGraphicalEffects 1.0
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
-import Esri.ArcGISRuntime.OpenSourceApps.Handheld 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
+import Esri.ArcGISRuntime.OpenSourceApps.Handheld 1.2
 import Esri.ArcGISRuntime.Toolkit.Controls 100.5
 import Esri.ArcGISRuntime.Toolkit.Controls.CppApi 100.5
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,15 @@
 # Release notes
 
+## 1.1.3
+
+- Minimum SDK version is now 20, target SDK version is 29.
+- Changed expected location of DSA files to match the changes Android
+  has made to scoped storage.
+  When previously data files needed copied to `/sdcard/ArcGIS/Runtime/DSA/Data`,
+  now data must be copied to `<AppDataLocation>/ArcGIS/Runtime/DSA/Data`.
+  For example, with the DSA Vehicle app, the data is expected to be located
+  at: `/sdcard/Android/data/com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt/ArcGIS/Runtime/DSA/Data`.
+
 ## 1.1.2
 
 - Updated to use version 100.8 of the ArcGIS Runtime SDK for Qt.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## 1.1.3
+## 1.2.0
 
 - Minimum SDK version is now 20, target SDK version is 29.
 - Changed expected location of DSA files to match the changes Android

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
   When previously data files needed copied to `/sdcard/ArcGIS/Runtime/DSA/Data`,
   now data must be copied to `<AppDataLocation>/ArcGIS/Runtime/DSA/Data`.
   For example, with the DSA Vehicle app, the data is expected to be located
-  at: `/sdcard/Android/data/com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt/ArcGIS/Runtime/DSA/Data`.
+  at: `/sdcard/Android/data/com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt/files/ArcGIS/Runtime/DSA/Data`.
 
 ## 1.1.2
 

--- a/Shared/DsaUtility.cpp
+++ b/Shared/DsaUtility.cpp
@@ -42,7 +42,8 @@ QString DsaUtility::dataPath()
 {
   QDir dataDir;
 #ifdef Q_OS_ANDROID
-  dataDir = QDir(QStringLiteral("/sdcard"));
+  const auto androidPaths = QStandardPaths::standardLocations(QStandardPaths::DataLocation);
+  dataDir = QDir(androidPaths.size() > 0 ? androidPaths.last() : "");
 #elif defined Q_OS_IOS
   dataDir = QDir(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
 #else

--- a/Shared/qml/About.qml
+++ b/Shared/qml/About.qml
@@ -19,7 +19,7 @@ import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
 import QtQuick.Layouts 1.3
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: aboutRoot

--- a/Shared/qml/AddLocalData.qml
+++ b/Shared/qml/AddLocalData.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 DsaPanel {
     id: localDataRoot

--- a/Shared/qml/AlertConditionsAttributeQueryPage.qml
+++ b/Shared/qml/AlertConditionsAttributeQueryPage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: queryPage

--- a/Shared/qml/AlertConditionsAttributeTarget.qml
+++ b/Shared/qml/AlertConditionsAttributeTarget.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: targetPage

--- a/Shared/qml/AlertConditionsConditionTypePage.qml
+++ b/Shared/qml/AlertConditionsConditionTypePage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: conditionPage

--- a/Shared/qml/AlertConditionsLevelPage.qml
+++ b/Shared/qml/AlertConditionsLevelPage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: levelPage

--- a/Shared/qml/AlertConditionsNamePage.qml
+++ b/Shared/qml/AlertConditionsNamePage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: namePage

--- a/Shared/qml/AlertConditionsSourcePage.qml
+++ b/Shared/qml/AlertConditionsSourcePage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: sourcePage

--- a/Shared/qml/AlertConditionsSpatialQueryPage.qml
+++ b/Shared/qml/AlertConditionsSpatialQueryPage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: queryPage

--- a/Shared/qml/AlertConditionsSpatialTarget.qml
+++ b/Shared/qml/AlertConditionsSpatialTarget.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
 

--- a/Shared/qml/AlertConditionsTool.qml
+++ b/Shared/qml/AlertConditionsTool.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 DsaPanel {
     id: manageAlertsRoot

--- a/Shared/qml/AlertConditionsWizard.qml
+++ b/Shared/qml/AlertConditionsWizard.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Rectangle {
     id: conditionsWizardRoot

--- a/Shared/qml/AlertList.qml
+++ b/Shared/qml/AlertList.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 DsaPanel {
     id: alertsRoot

--- a/Shared/qml/AlertToolRow.qml
+++ b/Shared/qml/AlertToolRow.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 import Esri.ArcGISRuntime.Toolkit.Controls.CppApi 100.5
 
 Row {

--- a/Shared/qml/AnalysisList.qml
+++ b/Shared/qml/AnalysisList.qml
@@ -19,7 +19,7 @@ import QtQml.Models 2.2
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 DsaPanel {
     id: analysisRoot

--- a/Shared/qml/AnalysisToolRow.qml
+++ b/Shared/qml/AnalysisToolRow.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Row {
     id: analysisToolRow

--- a/Shared/qml/BasemapPicker.qml
+++ b/Shared/qml/BasemapPicker.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 DsaPanel {
     signal basemapSelected();    

--- a/Shared/qml/CategoryIcon.qml
+++ b/Shared/qml/CategoryIcon.qml
@@ -17,7 +17,7 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 import QtQuick.Controls.Material 2.2
 
 Item {

--- a/Shared/qml/CategoryToolbar.qml
+++ b/Shared/qml/CategoryToolbar.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 import QtQuick.Controls.Material 2.2
 
 Item {

--- a/Shared/qml/CategoryToolbarColumn.qml
+++ b/Shared/qml/CategoryToolbarColumn.qml
@@ -17,7 +17,7 @@
 import QtQuick 2.9
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 import QtQuick.Controls.Material 2.2
 
 CategoryToolbar {

--- a/Shared/qml/CategoryToolbarRow.qml
+++ b/Shared/qml/CategoryToolbarRow.qml
@@ -17,7 +17,7 @@
 import QtQuick 2.9
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 import QtQuick.Controls.Material 2.2
 
 CategoryToolbar {

--- a/Shared/qml/ContactReportSizePage.qml
+++ b/Shared/qml/ContactReportSizePage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: reportDatePage

--- a/Shared/qml/ContextMenu.qml
+++ b/Shared/qml/ContextMenu.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Menu {
     id: contextMenu

--- a/Shared/qml/CurrentLocation.qml
+++ b/Shared/qml/CurrentLocation.qml
@@ -19,7 +19,7 @@ import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
 import QtQuick.Layouts 1.3
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 
 Item {

--- a/Shared/qml/DistressButton.qml
+++ b/Shared/qml/DistressButton.qml
@@ -15,7 +15,7 @@
  ******************************************************************************/
 
 import QtQuick 2.9
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 OverlayButton {
     id: distressButton

--- a/Shared/qml/DsaInputDialog.qml
+++ b/Shared/qml/DsaInputDialog.qml
@@ -20,7 +20,7 @@ import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
 import QtQml.Models 2.2
 import QtGraphicalEffects 1.0
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Dialog {
     property alias inputLabel: inputLabelText.text

--- a/Shared/qml/DsaMessageDialog.qml
+++ b/Shared/qml/DsaMessageDialog.qml
@@ -20,7 +20,7 @@ import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
 import QtQml.Models 2.2
 import QtGraphicalEffects 1.0
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Dialog {
     property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" || Qt.platform.os === "linux" ? 96 : 72)

--- a/Shared/qml/DsaPanel.qml
+++ b/Shared/qml/DsaPanel.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Rectangle {
     id: dsaPanel

--- a/Shared/qml/DsaYesNoDialog.qml
+++ b/Shared/qml/DsaYesNoDialog.qml
@@ -20,7 +20,7 @@ import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
 import QtQml.Models 2.2
 import QtGraphicalEffects 1.0
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Dialog {
     property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" || Qt.platform.os === "linux" ? 96 : 72)

--- a/Shared/qml/FollowHud.qml
+++ b/Shared/qml/FollowHud.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: followHudRoot

--- a/Shared/qml/HomeToolRow.qml
+++ b/Shared/qml/HomeToolRow.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 import Esri.ArcGISRuntime.Toolkit.Controls.CppApi 100.5
 
 Row {

--- a/Shared/qml/Imports.qml
+++ b/Shared/qml/Imports.qml
@@ -22,7 +22,7 @@ import QtQuick.Controls.Material 2.2
 import QtQuick.Layouts 1.1
 import QtQuick.Window 2.0
 import Esri.ArcGISRuntime.Toolkit.Controls.CppApi 100.5
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
 

--- a/Shared/qml/LineOfSightTool.qml
+++ b/Shared/qml/LineOfSightTool.qml
@@ -19,7 +19,7 @@ import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtGraphicalEffects 1.0
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: rootLineOfSight

--- a/Shared/qml/ListItemDelegate.qml
+++ b/Shared/qml/ListItemDelegate.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     property alias itemChecked: visibleCheckBox.checked

--- a/Shared/qml/ListLabel.qml
+++ b/Shared/qml/ListLabel.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" || Qt.platform.os === "linux" ? 96 : 72)

--- a/Shared/qml/ListSeparator.qml
+++ b/Shared/qml/ListSeparator.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Rectangle {
     property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" || Qt.platform.os === "linux" ? 96 : 72)

--- a/Shared/qml/MapToolRow.qml
+++ b/Shared/qml/MapToolRow.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 import Esri.ArcGISRuntime.Toolkit.Controls.CppApi 100.5
 
 Row {

--- a/Shared/qml/MarkupTool.qml
+++ b/Shared/qml/MarkupTool.qml
@@ -19,7 +19,7 @@ import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtGraphicalEffects 1.0
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: rootMarkup

--- a/Shared/qml/MarkupToolRow.qml
+++ b/Shared/qml/MarkupToolRow.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 import Esri.ArcGISRuntime.Toolkit.Controls.CppApi 100.5
 
 Row {

--- a/Shared/qml/MessageFeeds.qml
+++ b/Shared/qml/MessageFeeds.qml
@@ -17,7 +17,7 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 DsaPanel {
     id: messageFeedsRoot

--- a/Shared/qml/NavigationTool.qml
+++ b/Shared/qml/NavigationTool.qml
@@ -19,7 +19,7 @@ import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.2
 import QtQuick.Window 2.2
 import QtQuick.Controls.Material 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" || Qt.platform.os === "linux" ? 96 : 72)

--- a/Shared/qml/ObservationReportActivityPage.qml
+++ b/Shared/qml/ObservationReportActivityPage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: reportDatePage

--- a/Shared/qml/ObservationReportDescriptionPage.qml
+++ b/Shared/qml/ObservationReportDescriptionPage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: descriptionPage

--- a/Shared/qml/ObservationReportLocationPage.qml
+++ b/Shared/qml/ObservationReportLocationPage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: reportDatePage

--- a/Shared/qml/ObservationReportObservedByPage.qml
+++ b/Shared/qml/ObservationReportObservedByPage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: reportDatePage

--- a/Shared/qml/ObservationReportObservedTimePage.qml
+++ b/Shared/qml/ObservationReportObservedTimePage.qml
@@ -20,7 +20,7 @@ import QtQuick.Controls.Styles 1.4
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: observedTimePage

--- a/Shared/qml/ObservationReportSizePage.qml
+++ b/Shared/qml/ObservationReportSizePage.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: reportDatePage

--- a/Shared/qml/ObservationReportTool.qml
+++ b/Shared/qml/ObservationReportTool.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 DsaPanel {
     id: observationReportRoot

--- a/Shared/qml/OpenSceneTool.qml
+++ b/Shared/qml/OpenSceneTool.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 DsaPanel {
     width: parent.width

--- a/Shared/qml/Options.qml
+++ b/Shared/qml/Options.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Rectangle {
     id: optionsRoot

--- a/Shared/qml/OverlayButton.qml
+++ b/Shared/qml/OverlayButton.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Rectangle {
     id: overlayButton

--- a/Shared/qml/PrimaryToolbar.qml
+++ b/Shared/qml/PrimaryToolbar.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 import QtQuick.Controls.Material 2.2
 
 ToolBar {

--- a/Shared/qml/ReportToolRow.qml
+++ b/Shared/qml/ReportToolRow.qml
@@ -18,7 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 import Esri.ArcGISRuntime.Toolkit.Controls.CppApi 100.5
 
 Row {

--- a/Shared/qml/SecondaryToolbar.qml
+++ b/Shared/qml/SecondaryToolbar.qml
@@ -20,7 +20,7 @@ import QtQuick.Controls 1.4 as QtQuick1
 import QtQuick.Controls.Material 2.2
 import QtGraphicalEffects 1.0
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" || Qt.platform.os === "linux" ? 96 : 72)

--- a/Shared/qml/TableOfContents.qml
+++ b/Shared/qml/TableOfContents.qml
@@ -19,7 +19,7 @@ import QtQml.Models 2.2
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 DsaPanel {
     id: tocRoot

--- a/Shared/qml/ToolIcon.qml
+++ b/Shared/qml/ToolIcon.qml
@@ -17,7 +17,7 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 import QtQuick.Controls.Material 2.2
 
 Item {

--- a/Shared/qml/ViewedAlerts.qml
+++ b/Shared/qml/ViewedAlerts.qml
@@ -18,7 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Rectangle {
     property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" || Qt.platform.os === "linux" ? 96 : 72)

--- a/Shared/qml/Viewshed.qml
+++ b/Shared/qml/Viewshed.qml
@@ -19,7 +19,7 @@ import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
 import QtGraphicalEffects 1.0
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
 
 Item {
     id: rootViewshed

--- a/Vehicle/Android/Android.pri
+++ b/Vehicle/Android/Android.pri
@@ -22,5 +22,6 @@ ANDROID_PACKAGE_SOURCE_DIR = $$PWD
 OTHER_FILES +=     $$ANDROID_PACKAGE_SOURCE_DIR/res/drawable-ldpi/icon.png     $$ANDROID_PACKAGE_SOURCE_DIR/res/drawable-mdpi/icon.png     $$ANDROID_PACKAGE_SOURCE_DIR/res/drawable-hdpi/icon.png     $$ANDROID_PACKAGE_SOURCE_DIR/res/drawable-xhdpi/icon.png     $$ANDROID_PACKAGE_SOURCE_DIR/res/drawable-xxhdpi/icon.png
 
 DISTFILES += \
-    $$PWD/AndroidManifest.xml
-
+    $$PWD/AndroidManifest.xml \
+    $$PWD/build.gradle \
+    $$PWD/res/values/libs.xml \

--- a/Vehicle/Android/AndroidManifest.xml
+++ b/Vehicle/Android/AndroidManifest.xml
@@ -1,7 +1,19 @@
 <?xml version="1.0"?>
-<manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.1" android:versionCode="2" android:installLocation="auto">
-    <application android:hardwareAccelerated="true" android:icon="@drawable/icon" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="DSA_V_Qt" android:theme="@android:style/Theme.Holo.Light.NoActionBar">
-        <activity android:name="org.qtproject.qt5.android.bindings.QtActivity" android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation" android:screenOrientation="unspecified" android:label="DSA_V_Qt">
+<manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.3" android:versionCode="4" android:installLocation="auto">
+    <uses-sdk android:minSdkVersion="20" android:targetSdkVersion="29"/>
+
+    <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
+         Remove the comment if you do not require these default permissions. -->
+    <!-- %%INSERT_PERMISSIONS -->
+
+    <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
+         Remove the comment if you do not require these default features. -->
+    <!-- %%INSERT_FEATURES -->
+
+    <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
+
+    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="DSA_V_Qt">
+        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density" android:name="org.qtproject.qt5.android.bindings.QtActivity" android:label="DSA_V_Qt" android:screenOrientation="unspecified" android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -26,11 +38,25 @@
             <meta-data android:name="android.app.load_local_libs" android:value="-- %%INSERT_LOCAL_LIBS%% --"/>
             <meta-data android:name="android.app.load_local_jars" android:value="-- %%INSERT_LOCAL_JARS%% --"/>
             <meta-data android:name="android.app.static_init_classes" android:value="-- %%INSERT_INIT_CLASSES%% --"/>
+            <!-- Used to specify custom system library path to run with local system libs -->
+            <!-- <meta-data android:name="android.app.system_libs_prefix" android:value="/system/lib/"/> -->
             <!--  Messages maps -->
             <meta-data android:value="@string/ministro_not_found_msg" android:name="android.app.ministro_not_found_msg"/>
             <meta-data android:value="@string/ministro_needed_msg" android:name="android.app.ministro_needed_msg"/>
             <meta-data android:value="@string/fatal_error_msg" android:name="android.app.fatal_error_msg"/>
+            <meta-data android:value="@string/unsupported_android_version" android:name="android.app.unsupported_android_version"/>
             <!--  Messages maps -->
+
+            <!-- Splash screen -->
+            <!-- Orientation-specific (portrait/landscape) data is checked first. If not available for current orientation,
+                 then android.app.splash_screen_drawable. For best results, use together with splash_screen_sticky and
+                 use hideSplashScreen() with a fade-out animation from Qt Android Extras to hide the splash screen when you
+                 are done populating your window with content. -->
+            <!-- meta-data android:name="android.app.splash_screen_drawable_portrait" android:resource="@drawable/logo_portrait" / -->
+            <!-- meta-data android:name="android.app.splash_screen_drawable_landscape" android:resource="@drawable/logo_landscape" / -->
+            <!-- meta-data android:name="android.app.splash_screen_drawable" android:resource="@drawable/logo"/ -->
+            <!-- meta-data android:name="android.app.splash_screen_sticky" android:value="true"/ -->
+            <!-- Splash screen -->
 
             <!-- Background running -->
             <!-- Warning: changing this value to true may cause unexpected crashes if the
@@ -46,30 +72,26 @@
 
             <!-- extract android style -->
             <!-- available android:values :
+                * default - In most cases this will be the same as "full", but it can also be something else if needed, e.g., for compatibility reasons
                 * full - useful QWidget & Quick Controls 1 apps
                 * minimal - useful for Quick Controls 2 apps, it is much faster than "full"
                 * none - useful for apps that don't use any of the above Qt modules
                 -->
-            <meta-data android:name="android.app.extract_android_style" android:value="full"/>
+            <meta-data android:name="android.app.extract_android_style" android:value="default"/>
             <!-- extract android style -->
-            <!-- Splash screen -->
-            <meta-data android:name="android.app.splash_screen" android:resource="@layout/splash"/>
-            <!-- Splash screen -->
     </activity>
 
     <!-- For adding service(s) please check: https://wiki.qt.io/AndroidServices -->
 
     </application>
 
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="16"/>
-    <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+
     <uses-permission android:name="android.permission.BLUETOOTH"/>
-
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 </manifest>

--- a/Vehicle/Android/AndroidManifest.xml
+++ b/Vehicle/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.3" android:versionCode="4" android:installLocation="auto">
-    <uses-sdk android:minSdkVersion="20" android:targetSdkVersion="29"/>
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
          Remove the comment if you do not require these default permissions. -->

--- a/Vehicle/Android/AndroidManifest.xml
+++ b/Vehicle/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.3" android:versionCode="4" android:installLocation="auto">
+<manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.2.0" android:versionCode="4" android:installLocation="auto">
     <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.

--- a/Vehicle/Android/build.gradle
+++ b/Vehicle/Android/build.gradle
@@ -1,0 +1,57 @@
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.2.0'
+    }
+}
+
+repositories {
+    google()
+    jcenter()
+}
+
+apply plugin: 'com.android.application'
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
+}
+
+android {
+    /*******************************************************
+     * The following variables:
+     * - androidBuildToolsVersion,
+     * - androidCompileSdkVersion
+     * - qt5AndroidDir - holds the path to qt android files
+     *                   needed to build any Qt application
+     *                   on Android.
+     *
+     * are defined in gradle.properties file. This file is
+     * updated by QtCreator and androiddeployqt tools.
+     * Changing them manually might break the compilation!
+     *******************************************************/
+
+    compileSdkVersion androidCompileSdkVersion.toInteger()
+
+    buildToolsVersion '28.0.3'
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = [qt5AndroidDir + '/src', 'src', 'java']
+            aidl.srcDirs = [qt5AndroidDir + '/src', 'src', 'aidl']
+            res.srcDirs = [qt5AndroidDir + '/res', 'res']
+            resources.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            assets.srcDirs = ['assets']
+            jniLibs.srcDirs = ['libs']
+       }
+    }
+
+    lintOptions {
+        abortOnError false
+    }
+}

--- a/Vehicle/Android/res/values/libs.xml
+++ b/Vehicle/Android/res/values/libs.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <array name="qt_sources">
+        <item>https://download.qt.io/ministro/android/qt5/qt-5.9</item>
+    </array>
+
+    <!-- The following is handled automatically by the deployment tool. It should
+         not be edited manually. -->
+
+    <array name="bundled_libs">
+        <!-- %%INSERT_EXTRA_LIBS%% -->
+    </array>
+
+     <array name="qt_libs">
+         <!-- %%INSERT_QT_LIBS%% -->
+     </array>
+
+    <array name="bundled_in_lib">
+        <!-- %%INSERT_BUNDLED_IN_LIB%% -->
+    </array>
+    <array name="bundled_in_assets">
+        <!-- %%INSERT_BUNDLED_IN_ASSETS%% -->
+    </array>
+
+</resources>

--- a/Vehicle/AppInfo.h
+++ b/Vehicle/AppInfo.h
@@ -22,7 +22,7 @@
 #define kOrganizationDomain             "esri.com"
 
 #define kApplicationName                "DSA_Vehicle_Qt"
-#define kApplicationVersion             "1.1.1"
+#define kApplicationVersion             "1.2.0"
 #define kApplicationDescription         "Dynamic Situational Awareness - Vehicle app"
 
 #define kApplicationSourceUrl           "qrc:/qml/main.qml"

--- a/Vehicle/iOS/Info.plist
+++ b/Vehicle/iOS/Info.plist
@@ -59,11 +59,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-  <string>1.1.1</string>
+  <string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-  <string>1.1.1</string>
+  <string>1.2.0</string>
 	<key>NOTE</key>
 	<string>Built with ArcGIS Runtime SDK for Qt.</string>
 	<key>UIFileSharingEnabled</key>

--- a/Vehicle/main.cpp
+++ b/Vehicle/main.cpp
@@ -113,33 +113,33 @@ int main(int argc, char *argv[])
   QSettings::setDefaultFormat(kSettingsFormat);
 
   // Register the map view for QML
-  qmlRegisterType<SceneQuickView>("Esri.ArcGISRuntime.OpenSourceApps.Vehicle", 1, 1, "SceneView");
+  qmlRegisterType<SceneQuickView>("Esri.ArcGISRuntime.OpenSourceApps.Vehicle", 1, 2, "SceneView");
   qRegisterMetaType<PopupManager*>("PopupManager*");
 
   // Register the Vehicle (QQuickItem) for QML
-  qmlRegisterType<Dsa::Vehicle::Vehicle>("Esri.ArcGISRuntime.OpenSourceApps.Vehicle", 1, 1, "Vehicle");
-  qmlRegisterType<Dsa::BasemapPickerController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "BasemapPickerController");
-  qmlRegisterType<Dsa::AddLocalDataController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "AddLocalDataController");
-  qmlRegisterType<Dsa::LocationController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "LocationController");
-  qmlRegisterType<Dsa::MessageFeedsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "MessageFeedsController");
-  qmlRegisterType<Dsa::FollowPositionController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "FollowPositionController");
-  qmlRegisterType<Dsa::TableOfContentsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "TableOfContentsController");
-  qmlRegisterType<Dsa::NavigationController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "NavigationController");
-  qmlRegisterType<Dsa::MarkupController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "MarkupController");
-  qmlRegisterType<Dsa::ViewshedController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "ViewshedController");
-  qmlRegisterType<Dsa::OptionsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "OptionsController");
-  qmlRegisterSingletonType<Dsa::Vehicle::VehicleStyles>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "DsaStyles", &dsaStylesProvider);
-  qmlRegisterSingletonType<Dsa::DsaResources>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "DsaResources", &dsaResourcesProvider);
-  qmlRegisterType<Dsa::IdentifyController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "IdentifyController");
-  qmlRegisterType<Dsa::AlertListController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "AlertListController");
-  qmlRegisterType<Dsa::ViewedAlertsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "ViewedAlertsController");
-  qmlRegisterType<Dsa::LocationTextController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "LocationTextController");
-  qmlRegisterType<Dsa::AlertConditionsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "AlertConditionsController");
-  qmlRegisterType<Dsa::LineOfSightController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "LineOfSightController");
-  qmlRegisterType<Dsa::ContextMenuController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "ContextMenuController");
-  qmlRegisterType<Dsa::AnalysisListController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "AnalysisListController");
-  qmlRegisterType<Dsa::ObservationReportController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "ObservationReportController");
-  qmlRegisterType<Dsa::OpenMobileScenePackageController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 1, "OpenMobileScenePackageController");
+  qmlRegisterType<Dsa::Vehicle::Vehicle>("Esri.ArcGISRuntime.OpenSourceApps.Vehicle", 1, 2, "Vehicle");
+  qmlRegisterType<Dsa::BasemapPickerController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "BasemapPickerController");
+  qmlRegisterType<Dsa::AddLocalDataController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "AddLocalDataController");
+  qmlRegisterType<Dsa::LocationController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "LocationController");
+  qmlRegisterType<Dsa::MessageFeedsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "MessageFeedsController");
+  qmlRegisterType<Dsa::FollowPositionController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "FollowPositionController");
+  qmlRegisterType<Dsa::TableOfContentsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "TableOfContentsController");
+  qmlRegisterType<Dsa::NavigationController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "NavigationController");
+  qmlRegisterType<Dsa::MarkupController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "MarkupController");
+  qmlRegisterType<Dsa::ViewshedController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "ViewshedController");
+  qmlRegisterType<Dsa::OptionsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "OptionsController");
+  qmlRegisterSingletonType<Dsa::Vehicle::VehicleStyles>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "DsaStyles", &dsaStylesProvider);
+  qmlRegisterSingletonType<Dsa::DsaResources>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "DsaResources", &dsaResourcesProvider);
+  qmlRegisterType<Dsa::IdentifyController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "IdentifyController");
+  qmlRegisterType<Dsa::AlertListController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "AlertListController");
+  qmlRegisterType<Dsa::ViewedAlertsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "ViewedAlertsController");
+  qmlRegisterType<Dsa::LocationTextController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "LocationTextController");
+  qmlRegisterType<Dsa::AlertConditionsController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "AlertConditionsController");
+  qmlRegisterType<Dsa::LineOfSightController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "LineOfSightController");
+  qmlRegisterType<Dsa::ContextMenuController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "ContextMenuController");
+  qmlRegisterType<Dsa::AnalysisListController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "AnalysisListController");
+  qmlRegisterType<Dsa::ObservationReportController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "ObservationReportController");
+  qmlRegisterType<Dsa::OpenMobileScenePackageController>("Esri.ArcGISRuntime.OpenSourceApps.DSA", 1, 2, "OpenMobileScenePackageController");
 
   // Register Toolkit Component Types
   ArcGISRuntimeToolkit::registerToolkitTypes();

--- a/Vehicle/qml/main.qml
+++ b/Vehicle/qml/main.qml
@@ -19,8 +19,8 @@ import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.2
 import QtQuick.Window 2.2
 import QtQml.Models 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
-import Esri.ArcGISRuntime.OpenSourceApps.Vehicle 1.1
+import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.2
+import Esri.ArcGISRuntime.OpenSourceApps.Vehicle 1.2
 import Esri.ArcGISRuntime.Toolkit.Controls 100.5
 import Esri.ArcGISRuntime.Toolkit.Controls.CppApi 100.5
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -370,7 +370,7 @@ You can customize aspects of the DSA apps via a configuration file. When the DSA
 
 The configuration file is located at `~/ArcGIS/Runtime/Data/DSA/DsaAppConfig.json`, where `~` is `%username%`/`C:/Users/<username>` on Windows and `$HOME` on Unix.
 
-For DSA versions < 1.2, `~`, referred to `/sdcard` on Android. With the introduction of scoped storage in DSA versions >= 1.2, `~` is now dependent on the DSA app variant. For the vehicle variant of DSA (DSA_V_Qt), `~` is `/sdcard/Android/data/com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt/` and for the handheld variant of DSA (DSA_H_Qt), `~` is `/sdcard/Android/data/com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt/`.
+For DSA versions < 1.2, `~` was `/sdcard` on Android. With the introduction of scoped storage in DSA versions >= 1.2, `~` is now dependent on the DSA app variant. For the vehicle variant of DSA (DSA_V_Qt), `~` is `/sdcard/Android/data/com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt/files` and for the handheld variant of DSA (DSA_H_Qt), `~` is `/sdcard/Android/data/com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt/files`.
 
 The following lists some of the configuration settings that you can change.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -368,7 +368,9 @@ For convenience, you can try out the DSA apps compiled for [Windows] and [Androi
 
 You can customize aspects of the DSA apps via a configuration file. When the DSA app runs, the app will create a new configuration file if one is not found on local storage. When the app opens the configuration file, the file is read and its values used by the app for that run. Some settings may be changed at run time using the [Settings panel](#settings-panel). Those changes are persisted in the configuration file.
 
-The configuration file is located at `~/ArcGIS/Runtime/Data/DSA/DsaAppConfig.json`, where `~` is `%username%`/`C:/Users/<username>` on Windows, `$HOME` on Unix, and `/sdcard` on Android.
+The configuration file is located at `~/ArcGIS/Runtime/Data/DSA/DsaAppConfig.json`, where `~` is `%username%`/`C:/Users/<username>` on Windows and `$HOME` on Unix.
+
+For DSA versions < 1.2, `~`, referred to `/sdcard` on Android. With the introduction of scoped storage in DSA versions >= 1.2, `~` is now dependent on the DSA app variant. For the vehicle variant of DSA (DSA_V_Qt), `~` is `/sdcard/Android/data/com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt/` and for the handheld variant of DSA (DSA_H_Qt), `~` is `/sdcard/Android/data/com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt/`.
 
 The following lists some of the configuration settings that you can change.
 


### PR DESCRIPTION
- Minimum SDK version is now 20, target SDK version is 29. (Jump from minimum 16, target 16.)
- Changed expected location of DSA files to match the changes Android
  has made to scoped storage.
  When previously data files needed copied to `/sdcard/ArcGIS/Runtime/DSA/Data`,
  now data must be copied to `<AppDataLocation>/ArcGIS/Runtime/DSA/Data`.
  For example, with the DSA Vehicle app, the data is expected to be located
  at: `/sdcard/Android/data/com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt/ArcGIS/Runtime/DSA/Data/files`.