### PR TITLE
Anmacdonald/missing mspk

### DIFF
--- a/Shared/LayerCacheManager.cpp
+++ b/Shared/LayerCacheManager.cpp
@@ -256,7 +256,8 @@ void LayerCacheManager::layerToJson(Layer* layer)
   }
 
   // Don't serialize invalid layers or local files that don't actually exist in the file system.
-  auto isMissing = QUrl::fromUserInput(layerPath).isLocalFile() && !QFileInfo(layerPath).exists();
+  auto isMissing = QUrl::fromUserInput(layerPath, QDir::currentPath(), QUrl::AssumeLocalFile).isLocalFile()
+                 && !QFileInfo(layerPath).exists();
   if (layerPath.isEmpty() || isMissing)
   {
     return;

--- a/Shared/LayerCacheManager.cpp
+++ b/Shared/LayerCacheManager.cpp
@@ -255,8 +255,9 @@ void LayerCacheManager::layerToJson(Layer* layer)
     layerPath = kmlUrl.isLocalFile() ? kmlUrl.toLocalFile() : kmlUrl.toString();
   }
 
-  // Don't serialize invalid layers
-  if (layerPath.isEmpty())
+  // Don't serialize invalid layers or local files that don't actually exist in the file system.
+  auto isMissing = QUrl::fromUserInput(layerPath).isLocalFile() && !QFileInfo(layerPath).exists();
+  if (layerPath.isEmpty() || isMissing)
   {
     return;
   }


### PR DESCRIPTION
In some instances, paths belonging to SLPKs are serlialized to the layers output when they should be skipped. Unfortunately by the time we reach this area of functionality, the source of the layer has been lost and the path is relative to the root of the SLPK, not the position on the filesystem.

This workaround is to prevent serialization of files that are missing. Take the reasonable precaution of checking if a path _could_ be represented locally, and if that file actually exists. Under the assumption not all paths may be local, but unclear on that.