### PR TITLE
Fixed issue in exlclusion folder code.

### DIFF
--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -127,7 +127,7 @@ void DsaController::init(GeoView* geoView)
 
   m_cacheManager = new LayerCacheManager(this);
 
-  if (openScenePackageTool)
+  if (openScenePackageTool && !openScenePackageTool->packageDataPath().isEmpty())
     m_cacheManager->addExcludedPath(openScenePackageTool->packageDataPath());
 
   Toolkit::ToolResourceProvider::instance()->setScene(m_scene);

--- a/Shared/LayerCacheManager.cpp
+++ b/Shared/LayerCacheManager.cpp
@@ -266,6 +266,9 @@ void LayerCacheManager::layerToJson(Layer* layer)
   // Don't serialize data in excluded path locations
   for (const auto& excludedPath : m_excludedPaths)
   {
+    if (excludedPath.isEmpty())
+      continue;
+
     if (layerPath.startsWith(excludedPath))
       return;
   }


### PR DESCRIPTION
All layers are excluded in cases where the exclusion folder list contains an empty string. 
An empty string is inserted into the exclusion folder list when there is no `PackageDirectory` key on the config. 