### PR TITLE
Initial Location is written out on each scene switch.

### DIFF
--- a/Shared/AppConstants.cpp
+++ b/Shared/AppConstants.cpp
@@ -28,5 +28,6 @@ const QString AppConstants::UNIT_FEET = QStringLiteral("feet");
 const QString AppConstants::LAYERS_PROPERTYNAME = QStringLiteral("Layers");
 const QString AppConstants::CURRENTSCENE_PROPERTYNAME = QStringLiteral("CurrentPackage");
 const QString AppConstants::SCENEINDEX_PROPERTYNAME = QStringLiteral("SceneIndex");
+const QString AppConstants::INITIALLOCATION_PROPERTYNAME = QStringLiteral("InitialLocation");
 
 } // Dsa

--- a/Shared/AppConstants.h
+++ b/Shared/AppConstants.h
@@ -31,6 +31,7 @@ public:
   static const QString LAYERS_PROPERTYNAME;
   static const QString CURRENTSCENE_PROPERTYNAME;
   static const QString SCENEINDEX_PROPERTYNAME;
+  static const QString INITIALLOCATION_PROPERTYNAME;
 };
 
 } // Dsa

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -150,7 +150,7 @@ void DsaController::init(GeoView* geoView)
   // Only set the default scene if the scene package tool hasn't set a scene.
   if (!hasActiveScene)
   {
-    if (!m_dsaSettings.contains("InitialLocation"))
+    if (!m_dsaSettings.contains(AppConstants::INITIALLOCATION_PROPERTYNAME))
     {
       // While a scene change would normally write out the viewpoint
       // to config if/when it is missing, this here is a special case. We
@@ -158,7 +158,7 @@ void DsaController::init(GeoView* geoView)
       // using a distance measure. Extracting the viewpoint from the scene
       // will give us a calculated viewpoint with no distance measure, so we have
       // to set this manually.
-      m_dsaSettings["InitialLocation"] = defaultViewpoint();
+      m_dsaSettings[AppConstants::INITIALLOCATION_PROPERTYNAME] = defaultViewpoint();
     }
 
     Toolkit::ToolResourceProvider::instance()->setScene(m_scene);
@@ -540,12 +540,12 @@ void DsaController::writeInitialLocation(const Viewpoint& viewpoint)
   initialLocationJson.insert( QStringLiteral("pitch"), initialCamera.pitch());
   initialLocationJson.insert( QStringLiteral("roll"), initialCamera.roll());
 
-  m_dsaSettings[QStringLiteral("InitialLocation")] = initialLocationJson.toVariantMap();
+  m_dsaSettings[AppConstants::INITIALLOCATION_PROPERTYNAME] = initialLocationJson.toVariantMap();
 }
 
 Viewpoint DsaController::readInitialLocation()
 {
-  return viewpointFromJson(m_dsaSettings["InitialLocation"].toJsonObject());
+  return viewpointFromJson(m_dsaSettings[AppConstants::INITIALLOCATION_PROPERTYNAME].toJsonObject());
 }
 
 void DsaController::updateInitialLocationOnSceneChange(bool isInitialization)

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -53,10 +53,15 @@ using namespace Esri::ArcGISRuntime::Toolkit;
 
 namespace Dsa {
 
+namespace
+{
+
 bool readJsonFile(QIODevice& device, QSettings::SettingsMap& map);
 bool writeJsonFile(QIODevice& device, const QSettings::SettingsMap& map);
-Viewpoint viewpointFromJson(QJsonObject initialLocation);
+Viewpoint viewpointFromJson(const QJsonObject& initialLocation);
 QJsonObject defaultViewpoint();
+
+} // namespace
 
 /*!
   \class Dsa::DsaController
@@ -591,6 +596,9 @@ void DsaController::updateInitialLocationOnSceneChange(bool isInitialization)
   }
 }
 
+namespace
+{
+
 /*! \brief Read method for custom QSettings JSON format
  *
  * Attempts to read the information in \a device in a JSON format
@@ -630,7 +638,7 @@ bool writeJsonFile(QIODevice& device, const QSettings::SettingsMap& map)
   return writtenBytes != -1;
 }
 
-Viewpoint viewpointFromJson(QJsonObject initialLocation)
+Viewpoint viewpointFromJson(const QJsonObject& initialLocation)
 {
   if (initialLocation.isEmpty())
     return Viewpoint{};
@@ -683,7 +691,8 @@ QJsonObject defaultViewpoint()
   return defaultViewpoint;
 }
 
-} // Dsa
+} // namespace
+} // namespace Dsa
 
 // Signal Documentation
 

--- a/Shared/DsaController.h
+++ b/Shared/DsaController.h
@@ -50,7 +50,6 @@ public:
 
   void init(Esri::ArcGISRuntime::GeoView* geoView);
 
-  Esri::ArcGISRuntime::Viewpoint defaultViewpoint();
   void resetToDefaultScene();
 
 public slots:
@@ -64,7 +63,6 @@ signals:
   void errorOccurred(const QString& message, const QString& additionalMessage);
 
 private:
-  Esri::ArcGISRuntime::Viewpoint initialLocationFromConfig();
   void setupConfig();
   void createDefaultSettings();
   void saveSettings();
@@ -72,6 +70,10 @@ private:
   void writeDefaultConditions();
   void writeDefaultMessageFeeds();
   bool isConflictingTool(const QString& toolName) const;
+  void updateInitialLocationOnSceneChange(bool isInitialization);
+
+  void writeInitialLocation(const Esri::ArcGISRuntime::Viewpoint& viewpoint);
+  Esri::ArcGISRuntime::Viewpoint readInitialLocation();
 
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   LayerCacheManager* m_cacheManager = nullptr;

--- a/Shared/packages/OpenMobileScenePackageController.cpp
+++ b/Shared/packages/OpenMobileScenePackageController.cpp
@@ -499,7 +499,7 @@ void OpenMobileScenePackageController::updatePackageDetails()
  * \brief Returns \c true when there is a valid scene package
  * and scene index cached in this object.
  */
-bool OpenMobileScenePackageController::hasActiveScene()
+bool OpenMobileScenePackageController::hasActiveScene() const
 {
   return m_mspk && m_currentSceneIndex >= 0;
 }

--- a/Shared/packages/OpenMobileScenePackageController.cpp
+++ b/Shared/packages/OpenMobileScenePackageController.cpp
@@ -202,6 +202,7 @@ void OpenMobileScenePackageController::selectPackageName(const QString& newPacka
 void OpenMobileScenePackageController::selectScene(int newSceneIndex)
 {
   setCurrentSceneIndex(newSceneIndex);
+
   loadScene();
 }
 
@@ -492,6 +493,15 @@ void OpenMobileScenePackageController::updatePackageDetails()
     loadMobileScenePackage(packageName);
   }
 
+}
+
+/*!
+ * \brief Returns \c true when there is a valid scene package
+ * and scene index cached in this object.
+ */
+bool OpenMobileScenePackageController::hasActiveScene()
+{
+  return m_mspk && m_currentSceneIndex >= 0;
 }
 
 } // Dsa

--- a/Shared/packages/OpenMobileScenePackageController.h
+++ b/Shared/packages/OpenMobileScenePackageController.h
@@ -75,6 +75,8 @@ public:
 
   bool userSelected() const;
 
+  bool hasActiveScene();
+
 signals:
   void toolErrorOccurred(const QString& errorMessage, const QString& additionalMessage);
   void packageDataPathChanged();

--- a/Shared/packages/OpenMobileScenePackageController.h
+++ b/Shared/packages/OpenMobileScenePackageController.h
@@ -75,7 +75,7 @@ public:
 
   bool userSelected() const;
 
-  bool hasActiveScene();
+  bool hasActiveScene() const;
 
 signals:
   void toolErrorOccurred(const QString& errorMessage, const QString& additionalMessage);


### PR DESCRIPTION
InitialLocation is once again written out on startup, and with the addtion of MSPK support whenever the scene changes. The workflow is as follows:

1. User starts up app with no default config file. Immediately the default  config will be written out which contains the Monterey location.
1. The user clicks "`Open` -> Package name -> Scene in Package." The Scene loads.
   * The camera is placed at the loaded scene's initialLocation, the config file's initial location is changed to match.
1. The user closes the app.
1. The user reopens the app and the previous scene is loaded at the initial location in the config file, which matches the scene's.
1. The user closes the app again and manually updates the config file's initial location to Greenland.
1. The user loads the app. The scene is loaded and the camera is placed in Greenland.
1. The user clicks `Open` -> `Reset to Default Scene`.
1. The default scene is loaded. The camera is placed in Monterey. The config file is changed to Monterey.
