### PR TITLE
Upgrade the minimum SDK version to 23.

### DIFF
--- a/Handheld/Android/AndroidManifest.xml
+++ b/Handheld/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.6" android:versionCode="7" android:installLocation="auto">
-    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29"/>
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="29"/>
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
          Remove the comment if you do not require these default permissions. -->
     <!-- %%INSERT_PERMISSIONS -->

--- a/Vehicle/Android/AndroidManifest.xml
+++ b/Vehicle/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <manifest package="com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.1.6" android:versionCode="7" android:installLocation="auto">
-    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29"/>
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="29"/>
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
          Remove the comment if you do not require these default permissions. -->
     <!-- %%INSERT_PERMISSIONS -->


### PR DESCRIPTION
This is the minimum for 100.11.

Updating the minimum Android SDK requirement for 100.11. This will go into v.next and be ready for the next release of DSA whenever the time comes.

@GuillaumeBelz please review.

FYI @ldanzinger @anmacdonald 