### PR TITLE
Cleanup Alerts/Observation wizard buttons

### DIFF
--- a/Shared/qml/AlertConditionsTool.qml
+++ b/Shared/qml/AlertConditionsTool.qml
@@ -304,10 +304,9 @@ DsaPanel {
         }
         text: "Create new"
         font {
-            pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
+            pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.5
             bold: checked
         }
-        width: 96 * scaleFactor
         background: Rectangle {
             color: Material.accent
             border.color: Material.foreground

--- a/Shared/qml/AlertConditionsWizard.qml
+++ b/Shared/qml/AlertConditionsWizard.qml
@@ -222,7 +222,11 @@ Rectangle {
             height: nextButton.height
             width: nextButton.width
             text: "Back"
-            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.75
+            leftPadding: 0
+            rightPadding: 0
+            topPadding: 0
+            bottomPadding: 0
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.5
 
             onClicked: conditionFrame.decrementCurrentIndex();
         }
@@ -304,7 +308,11 @@ Rectangle {
             height: 32 * scaleFactor
             width: 64 * scaleFactor
             text: "Next"
-            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.75
+            leftPadding: 0
+            rightPadding: 0
+            topPadding: 0
+            bottomPadding: 0
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.5
 
             onClicked: conditionFrame.incrementCurrentIndex();
         }

--- a/Shared/qml/AlertConditionsWizard.qml
+++ b/Shared/qml/AlertConditionsWizard.qml
@@ -218,10 +218,11 @@ Rectangle {
             enabled: conditionFrame.currentIndex > 0
             opacity: enabled ? 1.0 : 0.0
             Layout.margins: wizardButtonsFactoredMargin
+            Material.roundedScale: Material.NotRounded
             height: nextButton.height
             width: nextButton.width
             text: "Back"
-            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.75
 
             onClicked: conditionFrame.decrementCurrentIndex();
         }
@@ -299,10 +300,11 @@ Rectangle {
                 right: wizardButtonsFactoredMargin
                 bottom: wizardButtonsFactoredMargin
             }
+            Material.roundedScale: Material.NotRounded
             height: 32 * scaleFactor
             width: 64 * scaleFactor
             text: "Next"
-            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.75
 
             onClicked: conditionFrame.incrementCurrentIndex();
         }

--- a/Shared/qml/AlertConditionsWizard.qml
+++ b/Shared/qml/AlertConditionsWizard.qml
@@ -17,6 +17,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.Material
+import QtQuick.Layouts
 import QtQuick.Window
 import Esri.ArcGISRuntime.OpenSourceApps.DSA
 
@@ -26,6 +27,7 @@ Rectangle {
 
     property bool readyToAdd: conditionFrame.currentItem == reviewPage
     property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" || Qt.platform.os === "linux" ? 96 : 72)
+    property real wizardButtonsFactoredMargin: 4 * scaleFactor
 
     Text {
         id: titleRow
@@ -92,7 +94,7 @@ Rectangle {
         clip: true
         anchors {
             top: pageIndicator.bottom
-            bottom: nextButton.top
+            bottom: wizardButtonRow.top
             left: parent.left
             right: parent.right
             margins: 8 * scaleFactor
@@ -204,97 +206,105 @@ Rectangle {
         }
     }
 
-    Button {
-        id: backButton
-        visible: conditionFrame.currentIndex > 0
+    RowLayout {
+        id: wizardButtonRow
         anchors {
-            left: conditionFrame.left
-            verticalCenter: nextButton.verticalCenter
-            margins: 8 * scaleFactor
-        }
-        height: nextButton.height
-        width: nextButton.width
-        text: "Back"
-        font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
-
-        onClicked: conditionFrame.decrementCurrentIndex();
-    }
-
-    Button {
-        id: nextButton
-        visible: conditionFrame.currentIndex < (conditionFrame.count -1) && conditionFrame.currentItem.valid
-        anchors {
-            right: conditionFrame.right
             bottom: parent.bottom
-            margins: 16 * scaleFactor
+            horizontalCenter: parent.horizontalCenter
+            margins: wizardButtonsFactoredMargin * 2
         }
-        height: 32 * scaleFactor
-        width: 64 * scaleFactor
-        text: "Next"
-        font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
+        Button {
+            id: backButton
+            enabled: conditionFrame.currentIndex > 0
+            opacity: enabled ? 1.0 : 0.0
+            Layout.margins: wizardButtonsFactoredMargin
+            height: nextButton.height
+            width: nextButton.width
+            text: "Back"
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
 
-        onClicked: conditionFrame.incrementCurrentIndex();
-    }
-
-    ToolIcon {
-        id: createButton
-        anchors {
-            verticalCenter: nextButton.verticalCenter
-            right: conditionFrame.horizontalCenter
-            margins: 4 * scaleFactor
+            onClicked: conditionFrame.decrementCurrentIndex();
         }
-        enabled: readyToAdd
-        opacity: enabled ? 1.0 : 0.5
-        iconSource: DsaResources.iconComplete
-        toolName: "Create"
-        visible: reviewText.visible
-        labelColor: Material.accent
-        onToolSelected: {
-            conditionsWizardRoot.visible = false;
-            if (conditionPage.isSpatial) {
-                if (queryLoader.item.isWithinDistance) {
-                    toolController.addWithinDistanceAlert(namePage.conditionName,
+
+        ToolIcon {
+            id: createButton
+            Layout.margins: {
+                left: 0
+                top: wizardButtonsFactoredMargin
+                right: wizardButtonsFactoredMargin
+                bottom: wizardButtonsFactoredMargin
+            }
+            enabled: readyToAdd
+            opacity: enabled ? 1.0 : 0.5
+            iconSource: DsaResources.iconComplete
+            toolName: "Create"
+            labelColor: Material.accent
+            onToolSelected: {
+                conditionsWizardRoot.visible = false;
+                if (conditionPage.isSpatial) {
+                    if (queryLoader.item.isWithinDistance) {
+                        toolController.addWithinDistanceAlert(namePage.conditionName,
+                                                              levelPage.getLevel(),
+                                                              sourcePage.sourceName,
+                                                              queryLoader.item.distance,
+                                                              targetLoader.item.targetFeatureId,
+                                                              targetLoader.item.targetIndex);
+                    } else if (queryLoader.item.isWithinArea) {
+                        toolController.addWithinAreaAlert(namePage.conditionName,
                                                           levelPage.getLevel(),
                                                           sourcePage.sourceName,
-                                                          queryLoader.item.distance,
                                                           targetLoader.item.targetFeatureId,
                                                           targetLoader.item.targetIndex);
-                } else if (queryLoader.item.isWithinArea) {
-                    toolController.addWithinAreaAlert(namePage.conditionName,
-                                                      levelPage.getLevel(),
-                                                      sourcePage.sourceName,
-                                                      targetLoader.item.targetFeatureId,
-                                                      targetLoader.item.targetIndex);
+                    }
+                } else if (conditionPage.isAttribute) {
+                    toolController.addAttributeEqualsAlert(namePage.conditionName,
+                                                           levelPage.getLevel(),
+                                                           sourcePage.sourceName,
+                                                           queryLoader.item.attributeField,
+                                                           targetLoader.item.attributeValue);
                 }
-            } else if (conditionPage.isAttribute) {
-                toolController.addAttributeEqualsAlert(namePage.conditionName,
-                                                       levelPage.getLevel(),
-                                                       sourcePage.sourceName,
-                                                       queryLoader.item.attributeField,
-                                                       targetLoader.item.attributeValue);
+
+                for (var i = 0; i < conditionFrame.count; ++i)
+                    conditionFrame.itemAt(i).clear();
+                conditionFrame.setCurrentIndex(0);
             }
-
-            for (var i = 0; i < conditionFrame.count; ++i)
-                conditionFrame.itemAt(i).clear();
-            conditionFrame.setCurrentIndex(0);
         }
-    }
 
-    ToolIcon {
-        id: cancelButton
-        anchors {
-            verticalCenter: nextButton.verticalCenter
-            left: conditionFrame.horizontalCenter
-            margins: 4 * scaleFactor
+        ToolIcon {
+            id: cancelButton
+            Layout.margins: {
+                left: 0
+                top: wizardButtonsFactoredMargin
+                right: wizardButtonsFactoredMargin
+                bottom: wizardButtonsFactoredMargin
+            }
+            toolName: "Cancel"
+            iconSource: DsaResources.iconClose
+
+            onToolSelected: {
+                conditionsWizardRoot.visible = false;
+                for (var i = 0; i < conditionFrame.count; ++i)
+                    conditionFrame.itemAt(i).clear();
+                conditionFrame.setCurrentIndex(0);
+            }
         }
-        toolName: "Cancel"
-        iconSource: DsaResources.iconClose
 
-        onToolSelected: {
-            conditionsWizardRoot.visible = false;
-            for (var i = 0; i < conditionFrame.count; ++i)
-                conditionFrame.itemAt(i).clear();
-            conditionFrame.setCurrentIndex(0);
+        Button {
+            id: nextButton
+            enabled: conditionFrame.currentIndex < (conditionFrame.count -1) && conditionFrame.currentItem.valid
+            opacity: enabled ? 1.0 : 0.0
+            Layout.margins: {
+                left: 0
+                top: wizardButtonsFactoredMargin
+                right: wizardButtonsFactoredMargin
+                bottom: wizardButtonsFactoredMargin
+            }
+            height: 32 * scaleFactor
+            width: 64 * scaleFactor
+            text: "Next"
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
+
+            onClicked: conditionFrame.incrementCurrentIndex();
         }
     }
 }

--- a/Shared/qml/AlertConditionsWizard.qml
+++ b/Shared/qml/AlertConditionsWizard.qml
@@ -27,7 +27,7 @@ Rectangle {
 
     property bool readyToAdd: conditionFrame.currentItem == reviewPage
     property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" || Qt.platform.os === "linux" ? 96 : 72)
-    property real wizardButtonsFactoredMargin: 4 * scaleFactor
+    readonly property real wizardButtonsFactoredMargin: 4 * scaleFactor
 
     Text {
         id: titleRow

--- a/Shared/qml/ObservationReportTool.qml
+++ b/Shared/qml/ObservationReportTool.qml
@@ -17,6 +17,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.Material
+import QtQuick.Layouts
 import QtQuick.Window
 import Esri.ArcGISRuntime.OpenSourceApps.DSA
 
@@ -29,6 +30,7 @@ DsaPanel {
     property alias pickMode: toolController.pickMode
     property bool  toolActive: toolController.active
     property bool readyToAdd: reportFrame.currentItem == reviewPage
+    property real wizardButtonsFactoredMargin: 4 * scaleFactor
 
     ObservationReportController {
         id: toolController
@@ -73,7 +75,7 @@ DsaPanel {
         clip: true
         anchors {
             top: pageIndicator.bottom
-            bottom: nextButton.top
+            bottom: wizardButtonRow.top
             left: parent.left
             right: parent.right
             margins: 8 * scaleFactor
@@ -182,87 +184,94 @@ DsaPanel {
         }
     }
 
-    Button {
-        id: backButton
-        visible: reportFrame.currentIndex > 0
+    RowLayout {
+        id: wizardButtonRow
         anchors {
-            left: reportFrame.left
-            verticalCenter: nextButton.verticalCenter
-            margins: 8 * scaleFactor
-        }
-        height: nextButton.height
-        width: nextButton.width
-        text: "Back"
-        font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
-
-        onClicked: reportFrame.decrementCurrentIndex();
-    }
-
-    Button {
-        id: nextButton
-        visible: reportFrame.currentIndex < (reportFrame.count -1) && reportFrame.currentItem.valid
-        anchors {
-            right: reportFrame.right
             bottom: parent.bottom
-            margins: 16 * scaleFactor
+            horizontalCenter: parent.horizontalCenter
+            margins: wizardButtonsFactoredMargin * 2
         }
-        height: 32 * scaleFactor
-        width: 64 * scaleFactor
-        text: "Next"
-        font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
+        Button {
+            id: backButton
+            enabled: reportFrame.currentIndex > 0
+            opacity: enabled ? 1.0 : 0.0
+            Layout.margins: wizardButtonsFactoredMargin
+            height: nextButton.height
+            width: nextButton.width
+            text: "Back"
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
 
-        onClicked: reportFrame.incrementCurrentIndex();
+            onClicked: reportFrame.decrementCurrentIndex();
+        }
+
+        ToolIcon {
+            id: createButton
+            Layout.margins: {
+                left: 0
+                top: wizardButtonsFactoredMargin
+                right: wizardButtonsFactoredMargin
+                bottom: wizardButtonsFactoredMargin
+            }
+            enabled: readyToAdd
+            opacity: enabled ? 1.0 : 0.5
+            iconSource: DsaResources.iconComplete
+            toolName: "Create"
+            labelColor: Material.accent
+            onToolSelected: {
+                toolController.broadcastReport(sizePage.size,
+                                               locationPage.locationDescription,
+                                               descriptionPage.enemyUnit,
+                                               activityPage.activity,
+                                               observedTimePage.observedTime,
+                                               "");
+
+                for (var i = 0; i < reportFrame.count; ++i)
+                    reportFrame.itemAt(i).clear();
+                reportFrame.setCurrentIndex(0);
+
+                if (isMobile)
+                    observationReportRoot.visible = false;
+            }
+        }
+
+        ToolIcon {
+            id: cancelButton
+            Layout.margins: {
+                left: 0
+                top: wizardButtonsFactoredMargin
+                right: wizardButtonsFactoredMargin
+                bottom: wizardButtonsFactoredMargin
+            }
+            toolName: "Cancel"
+            iconSource: DsaResources.iconClose
+
+            onToolSelected: {
+                for (var i = 0; i < reportFrame.count; ++i)
+                    reportFrame.itemAt(i).clear();
+                reportFrame.setCurrentIndex(0);
+                toolController.cancelReport();
+
+                if (isMobile)
+                    observationReportRoot.visible = false;
+            }
+        }
+
+        Button {
+            id: nextButton
+            enabled: reportFrame.currentIndex < (reportFrame.count -1) && reportFrame.currentItem.valid
+            opacity: enabled ? 1.0 : 0.0
+            Layout.margins: {
+                left: 0
+                top: wizardButtonsFactoredMargin
+                right: wizardButtonsFactoredMargin
+                bottom: wizardButtonsFactoredMargin
+            }
+            height: 32 * scaleFactor
+            width: 64 * scaleFactor
+            text: "Next"
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
+
+            onClicked: reportFrame.incrementCurrentIndex();
+        }
     }
-
-    ToolIcon {
-        id: createButton
-        anchors {
-            verticalCenter: nextButton.verticalCenter
-            right: reportFrame.horizontalCenter
-            margins: 4 * scaleFactor
-        }
-        enabled: readyToAdd
-        opacity: enabled ? 1.0 : 0.5
-        iconSource: DsaResources.iconComplete
-        toolName: "Create"
-        labelColor: Material.accent
-        onToolSelected: {
-
-            toolController.broadcastReport(sizePage.size,
-                                      locationPage.locationDescription,
-                                      descriptionPage.enemyUnit,
-                                      activityPage.activity,
-                                      observedTimePage.observedTime,
-                                      "");
-
-            for (var i = 0; i < reportFrame.count; ++i)
-                reportFrame.itemAt(i).clear();
-            reportFrame.setCurrentIndex(0);
-
-            if (isMobile)
-                observationReportRoot.visible = false;
-        }
-    }
-
-    ToolIcon {
-        id: cancelButton
-        anchors {
-            verticalCenter: nextButton.verticalCenter
-            left: reportFrame.horizontalCenter
-            margins: 4 * scaleFactor
-        }
-        toolName: "Cancel"
-        iconSource: DsaResources.iconClose
-
-        onToolSelected: {
-            for (var i = 0; i < reportFrame.count; ++i)
-                reportFrame.itemAt(i).clear();
-            reportFrame.setCurrentIndex(0);
-            toolController.cancelReport();
-
-            if (isMobile)
-                observationReportRoot.visible = false;
-        }
-    }
-
 }

--- a/Shared/qml/ObservationReportTool.qml
+++ b/Shared/qml/ObservationReportTool.qml
@@ -196,10 +196,11 @@ DsaPanel {
             enabled: reportFrame.currentIndex > 0
             opacity: enabled ? 1.0 : 0.0
             Layout.margins: wizardButtonsFactoredMargin
+            Material.roundedScale: Material.NotRounded
             height: nextButton.height
             width: nextButton.width
             text: "Back"
-            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.75
 
             onClicked: reportFrame.decrementCurrentIndex();
         }
@@ -266,10 +267,11 @@ DsaPanel {
                 right: wizardButtonsFactoredMargin
                 bottom: wizardButtonsFactoredMargin
             }
+            Material.roundedScale: Material.NotRounded
             height: 32 * scaleFactor
             width: 64 * scaleFactor
             text: "Next"
-            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.75
 
             onClicked: reportFrame.incrementCurrentIndex();
         }

--- a/Shared/qml/ObservationReportTool.qml
+++ b/Shared/qml/ObservationReportTool.qml
@@ -30,7 +30,7 @@ DsaPanel {
     property alias pickMode: toolController.pickMode
     property bool  toolActive: toolController.active
     property bool readyToAdd: reportFrame.currentItem == reviewPage
-    property real wizardButtonsFactoredMargin: 4 * scaleFactor
+    readonly property real wizardButtonsFactoredMargin: 4 * scaleFactor
 
     ObservationReportController {
         id: toolController

--- a/Shared/qml/ObservationReportTool.qml
+++ b/Shared/qml/ObservationReportTool.qml
@@ -200,7 +200,11 @@ DsaPanel {
             height: nextButton.height
             width: nextButton.width
             text: "Back"
-            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.75
+            leftPadding: 0
+            rightPadding: 0
+            topPadding: 0
+            bottomPadding: 0
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.5
 
             onClicked: reportFrame.decrementCurrentIndex();
         }
@@ -271,7 +275,11 @@ DsaPanel {
             height: 32 * scaleFactor
             width: 64 * scaleFactor
             text: "Next"
-            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.75
+            leftPadding: 0
+            rightPadding: 0
+            topPadding: 0
+            bottomPadding: 0
+            font.pixelSize: DsaStyles.toolFontPixelSize * scaleFactor * 1.5
 
             onClicked: reportFrame.incrementCurrentIndex();
         }


### PR DESCRIPTION
@JamesMBallard
please review.

relates to #384 

- added a property to store the margin factor needed around the wizard button row

- wrapped the buttons in a RowLayout to manage their alignment and spacing
- implemented same logic for both wizard panels
	- hiding forward and back buttons but making them take up the same space so controls don't shift around
	- keeping both create and cancel visible but fading create button when it isn't usable