### PR TITLE
Implementing DynamicEntity layer with LOS tools

### DIFF
--- a/Shared/ContextMenuController.cpp
+++ b/Shared/ContextMenuController.cpp
@@ -20,6 +20,8 @@
 #include "ContextMenuController.h"
 
 // C++ API headers
+#include "DynamicEntity.h"
+#include "DynamicEntityObservation.h"
 #include "Graphic.h"
 #include "GraphicsOverlay.h"
 #include "IdentifyGraphicsOverlayResult.h"
@@ -480,7 +482,14 @@ void ContextMenuController::selectOption(const QString& option)
           if (!geoElement || geoElement->geometry().geometryType() != GeometryType::Point)
             continue;
 
-          lineOfSightTool->lineOfSightFromLocationToGeoElement(geoElement);
+          // identify results of type observation require the dynamic entity they belong to
+          if (auto* dynamicEntityObservation = dynamic_cast<DynamicEntityObservation*>(geoElement); dynamicEntityObservation)
+          {
+            auto* dynamicEntityGeoElement = static_cast<GeoElement*>(dynamicEntityObservation->dynamicEntity());
+            lineOfSightTool->lineOfSightFromLocationToGeoElement(dynamicEntityGeoElement);
+          }
+          else
+            lineOfSightTool->lineOfSightFromLocationToGeoElement(geoElement);
         }
       }
     };

--- a/Shared/ContextMenuController.cpp
+++ b/Shared/ContextMenuController.cpp
@@ -489,7 +489,9 @@ void ContextMenuController::selectOption(const QString& option)
             lineOfSightTool->lineOfSightFromLocationToGeoElement(dynamicEntityGeoElement);
           }
           else
+          {
             lineOfSightTool->lineOfSightFromLocationToGeoElement(geoElement);
+          }
         }
       }
     };

--- a/Shared/analysis/LineOfSightController.cpp
+++ b/Shared/analysis/LineOfSightController.cpp
@@ -505,15 +505,14 @@ void LineOfSightController::setupNewLineOfSight(GeoElementLineOfSight* lineOfSig
   m_visibleByConnections.append(connect(lineOfSight, &GeoElementLineOfSight::targetVisibilityChanged, this, [this]()
   {
     int visibleCount = 0;
-    auto* losList = m_lineOfSightOverlay->analyses();
-    const int count = losList->rowCount();
-    for (int i = 0; i < count; ++i)
+    const auto* losList = m_lineOfSightOverlay->analyses();
+    for (auto losIt = losList->begin(); losIt < losList->end(); losIt++)
     {
-      auto* analysis = losList->at(i);
+      const auto* analysis = *losIt;
       if (!analysis)
         continue;
 
-      auto* lineOfSight = qobject_cast<GeoElementLineOfSight*>(analysis);
+      const auto* lineOfSight = qobject_cast<const GeoElementLineOfSight*>(analysis);
       if (!lineOfSight)
         continue;
 

--- a/Shared/analysis/LineOfSightController.h
+++ b/Shared/analysis/LineOfSightController.h
@@ -28,6 +28,7 @@ class QStringListModel;
 namespace Esri::ArcGISRuntime {
   class AnalysisOverlay;
   class GeoElement;
+  class GeoElementLineOfSight;
   class GeoView;
   class LayerListModel;
   class FeatureLayer;
@@ -81,10 +82,13 @@ private:
   void cancelTask();
   void getLocationGeoElement();
   void setVisibleByCount(int visibleByCount);
+  void updateLayerNames();
+  bool resetAnalysis(size_t featureCount);
+  void setupNewLineOfSight(Esri::ArcGISRuntime::GeoElementLineOfSight* lineOfSight);
 
   QStringListModel* m_overlayNames;
   Esri::ArcGISRuntime::GeoView* m_geoView = nullptr;
-  QList<Esri::ArcGISRuntime::FeatureLayer*> m_overlays;
+  QList<Esri::ArcGISRuntime::Layer*> m_overlays;
   Esri::ArcGISRuntime::AnalysisOverlay* m_lineOfSightOverlay = nullptr;
   QObject* m_lineOfSightParent = nullptr;
   Esri::ArcGISRuntime::GeoElement* m_locationGeoElement = nullptr;

--- a/Shared/analysis/LineOfSightController.h
+++ b/Shared/analysis/LineOfSightController.h
@@ -83,14 +83,14 @@ private:
   void getLocationGeoElement();
   void setVisibleByCount(int visibleByCount);
   void updateLayerNames();
-  bool resetAnalysis(size_t featureCount);
+  bool resetAnalysis(qsizetype featureCount);
   void setupNewLineOfSight(Esri::ArcGISRuntime::GeoElementLineOfSight* lineOfSight);
 
   QStringListModel* m_overlayNames;
   Esri::ArcGISRuntime::GeoView* m_geoView = nullptr;
   QList<Esri::ArcGISRuntime::Layer*> m_overlays;
   Esri::ArcGISRuntime::AnalysisOverlay* m_lineOfSightOverlay = nullptr;
-  QObject* m_lineOfSightParent = nullptr;
+  std::unique_ptr<QObject> m_lineOfSightParent = std::make_unique<QObject>();
   Esri::ArcGISRuntime::GeoElement* m_locationGeoElement = nullptr;
   QMetaObject::Connection m_queryFeaturesConnection;
   bool m_analysisVisible = true;


### PR DESCRIPTION
@JamesMBallard  please review

related #392 

- fetched the DynamicEntity from the DynamicEntityObservation returned on long press/context menu
- moved updateLayerNames from a lambda to a member function
- fixed an issue where layers were getting skipped due to a check returning early from missing curly braces missed during the 200.5 migration to QFuture
- implemented layer support for DynamicEntity types
- factored out code that was common to both FeatureLayer and DynamicEntityLayer
- using generic Layer for m_overlays list to allow for both FeatureLayer and DynamicEntityLayer