### PR TITLE
added a check method to prevent duplicate alerts from being added on startup

### DIFF
--- a/Handheld/qml/main.qml
+++ b/Handheld/qml/main.qml
@@ -14,14 +14,14 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.9
-import QtQuick.Controls 2.2
-import QtQuick.Controls.Material 2.2
-import QtQuick.Window 2.2
-import QtQml.Models 2.2
-import Esri.ArcGISRuntime.OpenSourceApps.DSA 1.1
-import Esri.ArcGISRuntime.OpenSourceApps.Handheld 1.1
-import Esri.ArcGISRuntime.Toolkit 100.10 as Toolkit
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Controls.Material
+import QtQuick.Window
+import QtQml.Models
+import Esri.ArcGISRuntime.OpenSourceApps.DSA
+import Esri.ArcGISRuntime.OpenSourceApps.Handheld
+import Esri.ArcGISRuntime.Toolkit as Toolkit
 
 Handheld {
     id: appRoot

--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -296,6 +296,7 @@ QFuture<bool> AlertConditionsController::addWithinDistanceAlertBySourceLayerType
   // make sure the condition has not already been added
   if (conditionAlreadyAdded(conditionName))
     return QtFuture::makeReadyFuture(false);
+
   auto* condition = new WithinDistanceAlertCondition(level, conditionName, distance, this);
   connect(condition, &WithinDistanceAlertCondition::newConditionData, this, &AlertConditionsController::handleNewAlertConditionData);
   condition->init(alertSourceLayer, sourceFeedName, target, targetDescription);
@@ -374,6 +375,7 @@ QFuture<bool> AlertConditionsController::addWithinAreaAlertBySourceLayerType(con
   // make sure the condition has not already been added
   if (conditionAlreadyAdded(conditionName))
     return QtFuture::makeReadyFuture(false);
+
   auto* condition = new WithinAreaAlertCondition(level, conditionName, this);
   connect(condition, &WithinAreaAlertCondition::newConditionData, this, &AlertConditionsController::handleNewAlertConditionData);
   condition->init(alertSourceLayer, sourceFeedName, target, targetDescription);
@@ -438,6 +440,7 @@ QFuture<bool> AlertConditionsController::addAttributeEqualsAlertBySourceLayerTyp
   // make sure the condition has not already been added
   if (conditionAlreadyAdded(conditionName))
     return QtFuture::makeReadyFuture(false);
+
   AlertTarget* target = new FixedValueAlertTarget(targetValue, this);
   AttributeEqualsAlertCondition* condition = new AttributeEqualsAlertCondition(level, conditionName, attributeName, this);
   connect(condition, &AttributeEqualsAlertCondition::newConditionData, this, &AlertConditionsController::handleNewAlertConditionData);

--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -293,6 +293,9 @@ QFuture<bool> AlertConditionsController::addWithinDistanceAlertBySourceLayerType
                                                                                  const QString& targetDescription,
                                                                                  T* alertSourceLayer)
 {
+  // make sure the condition has not already been added
+  if (conditionAlreadyAdded(conditionName))
+    return QtFuture::makeReadyFuture(false);
   auto* condition = new WithinDistanceAlertCondition(level, conditionName, distance, this);
   connect(condition, &WithinDistanceAlertCondition::newConditionData, this, &AlertConditionsController::handleNewAlertConditionData);
   condition->init(alertSourceLayer, sourceFeedName, target, targetDescription);
@@ -368,6 +371,9 @@ QFuture<bool> AlertConditionsController::addWithinAreaAlertBySourceLayerType(con
                                                                              const QString& targetDescription,
                                                                              T* alertSourceLayer)
 {
+  // make sure the condition has not already been added
+  if (conditionAlreadyAdded(conditionName))
+    return QtFuture::makeReadyFuture(false);
   auto* condition = new WithinAreaAlertCondition(level, conditionName, this);
   connect(condition, &WithinAreaAlertCondition::newConditionData, this, &AlertConditionsController::handleNewAlertConditionData);
   condition->init(alertSourceLayer, sourceFeedName, target, targetDescription);
@@ -429,6 +435,9 @@ QFuture<bool> AlertConditionsController::addAttributeEqualsAlertBySourceLayerTyp
                                                                                   const QVariant& targetValue,
                                                                                   T* alertSourceLayer)
 {
+  // make sure the condition has not already been added
+  if (conditionAlreadyAdded(conditionName))
+    return QtFuture::makeReadyFuture(false);
   AlertTarget* target = new FixedValueAlertTarget(targetValue, this);
   AttributeEqualsAlertCondition* condition = new AttributeEqualsAlertCondition(level, conditionName, attributeName, this);
   connect(condition, &AttributeEqualsAlertCondition::newConditionData, this, &AlertConditionsController::handleNewAlertConditionData);
@@ -1056,6 +1065,17 @@ void AlertConditionsController::addStoredConditions()
     this->blockSignals(false);
     onConditionsChanged();
   });
+}
+
+bool AlertConditionsController::conditionAlreadyAdded(const QString& conditionName)
+{
+  for (auto i = 0; i < m_conditions->rowCount(); i++)
+  {
+    const auto* condition = m_conditions->conditionAt(i);
+    if (condition->name() == conditionName)
+      return true;
+  }
+  return false;
 }
 
 /*!

--- a/Shared/alerts/AlertConditionsController.h
+++ b/Shared/alerts/AlertConditionsController.h
@@ -80,6 +80,7 @@ public:
   Q_INVOKABLE void togglePickMode();
   Q_INVOKABLE void updateConditionName(int rowIndex, const QString& conditionName);
   Q_INVOKABLE void updateConditionLevel(int rowIndex, int level);
+  Q_INVOKABLE bool conditionAlreadyAdded(const QString& conditionName);
 
   QAbstractItemModel* sourceNames() const;
   QAbstractItemModel* targetNames() const;
@@ -108,7 +109,6 @@ private:
   QJsonObject conditionToJson(AlertCondition* condition) const;
   QFuture<bool> addConditionFromJson(const QJsonObject& json);
   void addStoredConditions();
-  bool conditionAlreadyAdded(const QString& conditionName);
 
   QFuture<AlertTarget*> targetFromItemIdAndIndex(int itemId, int targetOverlayIndex, QString& targetDescription) const;
   QFuture<AlertTarget*> targetFromFeatureLayer(Esri::ArcGISRuntime::FeatureLayer* featureLayer, int itemId) const;

--- a/Shared/alerts/AlertConditionsController.h
+++ b/Shared/alerts/AlertConditionsController.h
@@ -108,6 +108,7 @@ private:
   QJsonObject conditionToJson(AlertCondition* condition) const;
   QFuture<bool> addConditionFromJson(const QJsonObject& json);
   void addStoredConditions();
+  bool conditionAlreadyAdded(const QString& conditionName);
 
   QFuture<AlertTarget*> targetFromItemIdAndIndex(int itemId, int targetOverlayIndex, QString& targetDescription) const;
   QFuture<AlertTarget*> targetFromFeatureLayer(Esri::ArcGISRuntime::FeatureLayer* featureLayer, int itemId) const;

--- a/Shared/qml/AlertConditionsNamePage.qml
+++ b/Shared/qml/AlertConditionsNamePage.qml
@@ -23,7 +23,8 @@ import Esri.ArcGISRuntime.OpenSourceApps.DSA
 Item {
     id: namePage
 
-    property bool valid: newAlertName.length > 0
+    property bool nameAlreadyInUse: toolController.conditionAlreadyAdded(newAlertName.text)
+    property bool valid: newAlertName.length > 0 && !nameAlreadyInUse
     property string instruction: "Set name"
     property alias conditionName: newAlertName.text
     property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" || Qt.platform.os === "linux" ? 96 : 72)
@@ -52,5 +53,20 @@ Item {
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         placeholderText: "<enter name>"
+    }
+    Label {
+        anchors {
+            horizontalCenter: parent.horizontalCenter
+            top: newAlertName.bottom
+            margins: 16 * scaleFactor
+        }
+        font {
+            pixelSize: DsaStyles.titleFontPixelSize * scaleFactor * 0.5
+            italic: true
+        }
+
+        color: "red"
+        opacity: nameAlreadyInUse ? 1.0 : 0.0
+        text: "Name already in use"
     }
 }

--- a/Shared/qml/AlertConditionsTool.qml
+++ b/Shared/qml/AlertConditionsTool.qml
@@ -181,8 +181,8 @@ DsaPanel {
                     width: parent.width
                     spacing: 10 * scaleFactor
                     leftPadding: 10 * scaleFactor
-                    property bool nameAlreadyInUse: !toolController.conditionAlreadyAdded(editConditionName.text)
-                    property bool valid: editConditionName.length > 0 && nameAlreadyInUse
+                    property bool nameAlreadyInUse: toolController.conditionAlreadyAdded(editConditionName.text)
+                    property bool valid: editConditionName.length > 0 && !nameAlreadyInUse
 
                     ComboBox {
                         id: editLevelBox
@@ -196,7 +196,7 @@ DsaPanel {
 
                     TextField {
                         id: editConditionName
-                        color: parent.nameAlreadyInUse ? Material.accent : "red"
+                        color: parent.nameAlreadyInUse ? "red" : Material.accent
                         font.pixelSize: 14 * scaleFactor
                         width: parent.width * 0.9
                         horizontalAlignment: Text.AlignLeft
@@ -248,8 +248,8 @@ DsaPanel {
             width: parent.width
             spacing: 10 * scaleFactor
             leftPadding: 10 * scaleFactor
-            property bool nameAlreadyInUseMobile: !toolController.conditionAlreadyAdded(editConditionMobileName.text)
-            property bool validMobile: editConditionMobileName.length > 0 && nameAlreadyInUseMobile
+            property bool nameAlreadyInUseMobile: toolController.conditionAlreadyAdded(editConditionMobileName.text)
+            property bool validMobile: editConditionMobileName.length > 0 && !nameAlreadyInUseMobile
 
             ComboBox {
                 id: editLevelMobileBox
@@ -263,7 +263,7 @@ DsaPanel {
 
             TextField {
                 id: editConditionMobileName
-                color: parent.nameAlreadyInUseMobile ? Material.accent : "red"
+                color: parent.nameAlreadyInUseMobile ? "red" : Material.accent
                 font.pixelSize: 14 * scaleFactor
                 width: parent.width * 0.9
                 horizontalAlignment: Text.AlignLeft

--- a/Shared/qml/AlertConditionsTool.qml
+++ b/Shared/qml/AlertConditionsTool.qml
@@ -249,7 +249,7 @@ DsaPanel {
             spacing: 10 * scaleFactor
             leftPadding: 10 * scaleFactor
             property bool nameAlreadyInUseMobile: !toolController.conditionAlreadyAdded(editConditionMobileName.text)
-            property bool validMobile: editConditionMobileName.length > 0 && nameIsValid
+            property bool validMobile: editConditionMobileName.length > 0 && nameAlreadyInUseMobile
 
             ComboBox {
                 id: editLevelMobileBox

--- a/Shared/qml/AlertConditionsTool.qml
+++ b/Shared/qml/AlertConditionsTool.qml
@@ -181,6 +181,8 @@ DsaPanel {
                     width: parent.width
                     spacing: 10 * scaleFactor
                     leftPadding: 10 * scaleFactor
+                    property bool nameAlreadyInUse: !toolController.conditionAlreadyAdded(editConditionName.text)
+                    property bool valid: editConditionName.length > 0 && nameAlreadyInUse
 
                     ComboBox {
                         id: editLevelBox
@@ -194,7 +196,7 @@ DsaPanel {
 
                     TextField {
                         id: editConditionName
-                        color: Material.accent
+                        color: parent.nameAlreadyInUse ? Material.accent : "red"
                         font.pixelSize: 14 * scaleFactor
                         width: parent.width * 0.9
                         horizontalAlignment: Text.AlignLeft
@@ -208,6 +210,8 @@ DsaPanel {
                         OverlayButton {
                             id: keepEditsButton
                             iconUrl: DsaResources.iconComplete
+                            enabled: parent.parent.valid
+                            opacity: parent.parent.valid ? 1.0 : 0.5
 
                             onClicked: {
                                 editMenu.close();
@@ -244,6 +248,8 @@ DsaPanel {
             width: parent.width
             spacing: 10 * scaleFactor
             leftPadding: 10 * scaleFactor
+            property bool nameAlreadyInUseMobile: !toolController.conditionAlreadyAdded(editConditionMobileName.text)
+            property bool validMobile: editConditionMobileName.length > 0 && nameIsValid
 
             ComboBox {
                 id: editLevelMobileBox
@@ -257,7 +263,7 @@ DsaPanel {
 
             TextField {
                 id: editConditionMobileName
-                color: Material.accent
+                color: parent.nameAlreadyInUseMobile ? Material.accent : "red"
                 font.pixelSize: 14 * scaleFactor
                 width: parent.width * 0.9
                 horizontalAlignment: Text.AlignLeft
@@ -270,6 +276,8 @@ DsaPanel {
 
                 OverlayButton {
                     iconUrl: DsaResources.iconComplete
+                    enabled: parent.parent.validMobile
+                    opacity: parent.parent.validMobile ? 1.0 : 0.5
 
                     onClicked: {
                         if (conditionsList.currentName !== editConditionMobileName.text)


### PR DESCRIPTION
@JamesMBallard 
please review

The introduction of QFuture caused a similar loading issue when a unique feature from within a layer used as the target is selected for the alert. When the query goes out to the table, subsequent calls to this method can occur and cause multiple alerts to be created for the same alert as other properties change within the application's configuration.

#394 