### PR TITLE
Remove remaining include for TaskWatcher from DSA

### DIFF
--- a/Shared/pch.hpp
+++ b/Shared/pch.hpp
@@ -34,7 +34,6 @@
 #include "Point.h"
 #include "Scene.h"
 #include "SceneView.h"
-#include "TaskWatcher.h"
 
 // Qt headers
 #include <QAbstractListModel>


### PR DESCRIPTION
@JamesMBallard 

patch to remove the include from the precompiled header

#368 