### PR TITLE
Download/Home paths

### DIFF
--- a/Shared/DsaUtility.cpp
+++ b/Shared/DsaUtility.cpp
@@ -56,10 +56,10 @@ QString DsaUtility::configurationsDirectoryPath()
     return fullPathToConfigurationsDirectory;
 
   // setup the root directory based on the os/platform
-#if defined Q_OS_ANDROID || defined Q_OS_IOS
+#ifdef Q_OS_IOS
   QDir dir{QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)};
 #else
-  QDir dir{QDir::home()};
+  QDir dir{QStandardPaths::writableLocation(QStandardPaths::HomeLocation)};
 #endif
 
   // append the standard path to the dsa application data folder structure

--- a/Shared/configurations/ConfigurationController.cpp
+++ b/Shared/configurations/ConfigurationController.cpp
@@ -47,7 +47,7 @@ ConfigurationController::ConfigurationController(QObject* parent /* = nullptr */
   m_networkAccessManager.setAutoDeleteReplies(true);
 
   // set the downloads folder based on the system type
-#if defined Q_OS_IOS || defined Q_OS_ANDROID
+#ifdef Q_OS_IOS
   m_downloadFolder = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
 #else
   m_downloadFolder = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);

--- a/Shared/utilities/ZipHelper.cpp
+++ b/Shared/utilities/ZipHelper.cpp
@@ -691,14 +691,10 @@ QString ZipHelper::defaultPathVariable(const QString& name)
 
 QString ZipHelper::defaultHomePath()
 {
-  QString homePath;
-
-#ifdef Q_OS_ANDROID
-  homePath = "/sdcard";
-#elif defined Q_OS_IOS
-  homePath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+#ifdef Q_OS_IOS
+  QString homePath{QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)};
 #else
-  homePath = QDir::homePath();
+  QString homePath{QStandardPaths::writableLocation(QStandardPaths::HomeLocation)};
 #endif
 
   return homePath;


### PR DESCRIPTION
Standardized all paths for downloading and storing files for DSA. Two locations in the latest update for the Configurations manager referenced these symbolic locations. There was also a legacy reference to /sdcard for Android in the ZipHelper.

iOS downloads - `Documents`
iOS files - `Documents`

all others downloads - `Downloads`
all others files - `Home`

#375

@JamesMBallard 