### PR TITLE
Xcode 16 compatibility.

### DIFF
--- a/Handheld/iOS/Info.plist
+++ b/Handheld/iOS/Info.plist
@@ -53,7 +53,7 @@
        </dict>
     </dict>
 	<key>CFBundleIdentifier</key>
-  <string>com.esri.arcgisruntime.opensourceapps.${PRODUCT_NAME:rfc1034identifier}</string>
+  <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/Vehicle/iOS/Info.plist
+++ b/Vehicle/iOS/Info.plist
@@ -53,7 +53,7 @@
        </dict>
     </dict>
 	<key>CFBundleIdentifier</key>
-  <string>com.esri.arcgisruntime.opensourceapps.${PRODUCT_NAME:rfc1034identifier}</string>
+  <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
As described [here](https://developer.apple.com/documentation/bundleresources/managing-your-app-s-information-property-list#:~:text=%24(PRODUCT_BUNDLE_IDENTIFIER).), update the `CFBundleIdentifier` for Xcode 16 compatibility

This PR is for `v.next`.

cc @dtedder 