### PR TITLE
Add ZOffset and SurfacePlacement to config file

### DIFF
--- a/3rdparty/zlib-ng/zutil.h
+++ b/3rdparty/zlib-ng/zutil.h
@@ -103,7 +103,7 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 #  define OS_CODE  6
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if defined(MACOS)
 #  define OS_CODE  7
 #endif
 

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -49,6 +49,7 @@
 #include "ContextMenuController.h"
 #include "DsaUtility.h"
 #include "LayerCacheManager.h"
+#include "LocationController.h"
 #include "MessageFeedConstants.h"
 #include "OpenMobileScenePackageController.h"
 #include "ToolManager.h"
@@ -501,12 +502,14 @@ void DsaController::createDefaultSettings()
   m_dsaSettings["BasemapDirectory"] = QString("%1/BasemapData").arg(m_dsaSettings["RootDataDirectory"].toString());
   m_dsaSettings["ElevationDirectory"] = QString("%1/ElevationData").arg(m_dsaSettings["RootDataDirectory"].toString());
   m_dsaSettings["SimulationDirectory"] = QString("%1/SimulationData").arg(m_dsaSettings["RootDataDirectory"].toString());
-  m_dsaSettings["ResourceDirectory"] = QString("%1/ResourceData").arg(m_dsaSettings["RootDataDirectory"].toString());
+  m_dsaSettings[LocationController::PROPERTY_NAME_RESOURCE_DIRECTORY] = QString("%1/ResourceData").arg(m_dsaSettings["RootDataDirectory"].toString());
   writeDefaultLocalDataPaths();
   m_dsaSettings["DefaultBasemap"] = QStringLiteral("topographic");
   m_dsaSettings["DefaultElevationSource"] = QString("%1/CaDEM.tpk").arg(m_dsaSettings["ElevationDirectory"].toString());
-  m_dsaSettings["GpxFile"] = QString("%1/MontereyMounted.gpx").arg(m_dsaSettings["SimulationDirectory"].toString());
-  m_dsaSettings["SimulateLocation"] = QStringLiteral("true");
+  m_dsaSettings[LocationController::PROPERTY_NAME_GPX_FILE] = QString("%1/MontereyMounted.gpx").arg(m_dsaSettings["SimulationDirectory"].toString());
+  m_dsaSettings[LocationController::PROPERTY_NAME_SIMULATE_LOCATION] = QStringLiteral("true");
+  m_dsaSettings[LocationController::PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET] = QStringLiteral("10");
+  m_dsaSettings[LocationController::PROPERTY_NAME_SURFACE_PLACEMENT] = QStringLiteral("Relative");
   writeDefaultMessageFeeds();
   m_dsaSettings["CoordinateFormat"] = Esri::ArcGISRuntime::Toolkit::CoordinateConversionConstants::MGRS_FORMAT;
   m_dsaSettings[AppConstants::UNIT_OF_MEASUREMENT_PROPERTYNAME] = AppConstants::UNIT_METERS;

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -509,7 +509,7 @@ void DsaController::createDefaultSettings()
   m_dsaSettings[LocationController::PROPERTY_NAME_GPX_FILE] = QString("%1/MontereyMounted.gpx").arg(m_dsaSettings["SimulationDirectory"].toString());
   m_dsaSettings[LocationController::PROPERTY_NAME_SIMULATE_LOCATION] = QStringLiteral("true");
   m_dsaSettings[LocationController::PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET] = QStringLiteral("10");
-  m_dsaSettings[LocationController::PROPERTY_NAME_SURFACE_PLACEMENT] = QStringLiteral("Relative");
+  m_dsaSettings[LocationController::PROPERTY_NAME_CURRENT_LOCATION_SURFACE_PLACEMENT] = QStringLiteral("Relative");
   writeDefaultMessageFeeds();
   m_dsaSettings["CoordinateFormat"] = Esri::ArcGISRuntime::Toolkit::CoordinateConversionConstants::MGRS_FORMAT;
   m_dsaSettings[AppConstants::UNIT_OF_MEASUREMENT_PROPERTYNAME] = AppConstants::UNIT_METERS;

--- a/Shared/LocationController.cpp
+++ b/Shared/LocationController.cpp
@@ -214,14 +214,11 @@ void LocationController::setProperties(const QVariantMap& properties)
 
   // make sure the value from the configuration file for
   // the z offset is able to be converted to a double
-  bool ok;
-  double offset = properties[PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET].toString().toDouble(&ok);
-  if (ok)
-    m_locationDisplay3d->setZOffset(offset);
+  if (const auto zOffsetValue = properties[PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET]; zOffsetValue.canConvert<double>())
+    m_locationDisplay3d->setZOffset(zOffsetValue.toDouble());
 
   // allow for the option to use draped-flat style surface placement, otherwise default to relative
-  auto surfacePlacementValue = properties[PROPERTY_NAME_CURRENT_LOCATION_SURFACE_PLACEMENT].toString();
-  if (surfacePlacementValue == QStringLiteral("DrapedFlat"))
+  if (const auto surfacePlacementValue = properties[PROPERTY_NAME_CURRENT_LOCATION_SURFACE_PLACEMENT].toString(); surfacePlacementValue == QStringLiteral("DrapedFlat"))
     m_locationDisplay3d->setSurfacePlacement(SurfacePlacement::DrapedFlat);
   else
     m_locationDisplay3d->setSurfacePlacement(SurfacePlacement::Relative);

--- a/Shared/LocationController.cpp
+++ b/Shared/LocationController.cpp
@@ -220,7 +220,7 @@ void LocationController::setProperties(const QVariantMap& properties)
     m_locationDisplay3d->setZOffset(offset);
 
   // allow for the option to use draped-flat style surface placement, otherwise default to relative
-  auto surfacePlacementValue = properties[PROPERTY_NAME_SURFACE_PLACEMENT].toString();
+  auto surfacePlacementValue = properties[PROPERTY_NAME_CURRENT_LOCATION_SURFACE_PLACEMENT].toString();
   if (surfacePlacementValue == QStringLiteral("DrapedFlat"))
     m_locationDisplay3d->setSurfacePlacement(SurfacePlacement::DrapedFlat);
   else

--- a/Shared/LocationController.h
+++ b/Shared/LocationController.h
@@ -49,9 +49,11 @@ class LocationController : public AbstractTool
   Q_PROPERTY(QString gpxFilePath READ gpxFilePath WRITE setGpxFilePath NOTIFY gpxFilePathChanged)
 
 public:
-  static const QString SIMULATE_LOCATION_PROPERTYNAME;
-  static const QString GPX_FILE_PROPERTYNAME;
-  static const QString RESOURCE_DIRECTORY_PROPERTYNAME;
+  inline static const QString PROPERTY_NAME_SIMULATE_LOCATION = QStringLiteral("SimulateLocation");
+  inline static const QString PROPERTY_NAME_GPX_FILE = QStringLiteral("GpxFile");
+  inline static const QString PROPERTY_NAME_RESOURCE_DIRECTORY = QStringLiteral("ResourceDirectory");
+  inline static const QString PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET = QStringLiteral("CurrentLocationZOffset");
+  inline static const QString PROPERTY_NAME_SURFACE_PLACEMENT = QStringLiteral("SurfacePlacement");
 
   explicit LocationController(QObject* parent = nullptr);
   ~LocationController();

--- a/Shared/LocationController.h
+++ b/Shared/LocationController.h
@@ -53,7 +53,7 @@ public:
   inline static const QString PROPERTY_NAME_GPX_FILE = QStringLiteral("GpxFile");
   inline static const QString PROPERTY_NAME_RESOURCE_DIRECTORY = QStringLiteral("ResourceDirectory");
   inline static const QString PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET = QStringLiteral("CurrentLocationZOffset");
-  inline static const QString PROPERTY_NAME_SURFACE_PLACEMENT = QStringLiteral("SurfacePlacement");
+  inline static const QString PROPERTY_NAME_CURRENT_LOCATION_SURFACE_PLACEMENT = QStringLiteral("CurrentLocationSurfacePlacement");
 
   explicit LocationController(QObject* parent = nullptr);
   ~LocationController();

--- a/Shared/LocationDisplay3d.cpp
+++ b/Shared/LocationDisplay3d.cpp
@@ -114,6 +114,22 @@ bool LocationDisplay3d::isStarted() const
   return m_isStarted;
 }
 
+void LocationDisplay3d::setZOffset(double offset)
+{
+  m_zOffset = offset;
+}
+
+double LocationDisplay3d::zOffset() const
+{
+  return m_zOffset;
+}
+
+void LocationDisplay3d::setSurfacePlacement(SurfacePlacement surfacePlacement)
+{
+  m_surfacePlacement = surfacePlacement;
+  m_locationOverlay->setSceneProperties(LayerSceneProperties{surfacePlacement});
+}
+
 /*!
   \brief Returns the position source for the location display.
  */
@@ -158,9 +174,7 @@ void LocationDisplay3d::setPositionSource(QGeoPositionInfoSource* positionSource
       return;
     }
 
-    // display position 10m off the ground
-    constexpr double elevatedZ = 10.0;
-    m_lastKnownLocation = Point(pos.longitude(), pos.latitude(), elevatedZ, SpatialReference::wgs84());
+    m_lastKnownLocation = Point(pos.longitude(), pos.latitude(), zOffset(), SpatialReference::wgs84());
     m_locationGraphic->setGeometry(m_lastKnownLocation);
 
     emit locationChanged(m_lastKnownLocation);

--- a/Shared/LocationDisplay3d.cpp
+++ b/Shared/LocationDisplay3d.cpp
@@ -46,8 +46,6 @@ using namespace Esri::ArcGISRuntime;
 
 namespace Dsa {
 
-static const QString s_headingAttribute{"heading"};
-
 /*!
   \class Dsa::LocationDisplay3d
   \inmodule Dsa
@@ -71,7 +69,7 @@ LocationDisplay3d::LocationDisplay3d(QObject* parent) :
   m_locationOverlay->setRenderingMode(GraphicsRenderingMode::Dynamic);
   m_locationOverlay->setVisible(false);
 
-  m_locationGraphic->attributes()->insertAttribute(s_headingAttribute, 0.0);
+  m_locationGraphic->attributes()->insertAttribute(ATTRIBUTE_NAME_HEADING, 0.0);
   m_locationOverlay->graphics()->append(m_locationGraphic);
 }
 
@@ -188,7 +186,7 @@ void LocationDisplay3d::setPositionSource(QGeoPositionInfoSource* positionSource
 
     m_headingConnection = connect(gpxLocationSimulator, &GPXLocationSimulator::headingChanged, this, [this](double heading)
     {
-      m_locationGraphic->attributes()->replaceAttribute(s_headingAttribute, heading);
+      m_locationGraphic->attributes()->replaceAttribute(ATTRIBUTE_NAME_HEADING, heading);
     });
   }
 
@@ -226,7 +224,7 @@ void LocationDisplay3d::setCompass(QCompass* compass)
     if (!reading)
       return;
 
-    m_locationGraphic->attributes()->replaceAttribute(s_headingAttribute, static_cast<double>(reading->azimuth()));
+    m_locationGraphic->attributes()->replaceAttribute(ATTRIBUTE_NAME_HEADING, static_cast<double>(reading->azimuth()));
 
     emit headingChanged();
   });
@@ -270,7 +268,7 @@ void LocationDisplay3d::setDefaultSymbol(Symbol* defaultSymbol)
     m_locationRenderer = new SimpleRenderer(defaultSymbol, this);
 
     RendererSceneProperties renderProperties = m_locationRenderer->sceneProperties();
-    renderProperties.setHeadingExpression(QString("[%1]").arg(s_headingAttribute));
+    renderProperties.setHeadingExpression(QString("[%1]").arg(ATTRIBUTE_NAME_HEADING));
     m_locationRenderer->setSceneProperties(renderProperties);
 
     m_locationOverlay->setRenderer(m_locationRenderer);

--- a/Shared/LocationDisplay3d.h
+++ b/Shared/LocationDisplay3d.h
@@ -73,6 +73,8 @@ signals:
 private:
   Q_DISABLE_COPY(LocationDisplay3d)
 
+  inline static const QString ATTRIBUTE_NAME_HEADING = QStringLiteral("heading");
+
   void postLastKnownLocationUpdate();
 
   mutable Esri::ArcGISRuntime::GraphicsOverlay* m_locationOverlay = nullptr;

--- a/Shared/LocationDisplay3d.h
+++ b/Shared/LocationDisplay3d.h
@@ -28,6 +28,7 @@ namespace Esri::ArcGISRuntime {
   class GraphicsOverlay;
   class Symbol;
   class SimpleRenderer;
+  enum class SurfacePlacement;
 }
 
 class QGeoPositionInfoSource;
@@ -46,6 +47,11 @@ public:
   void start();
   void stop();
   bool isStarted() const;
+
+  void setZOffset(double offset);
+  double zOffset() const;
+
+  void setSurfacePlacement(Esri::ArcGISRuntime::SurfacePlacement surfacePlacement);
 
   QGeoPositionInfoSource* positionSource() const;
   void setPositionSource(QGeoPositionInfoSource* positionSource);
@@ -77,6 +83,8 @@ private:
   QCompass* m_compass = nullptr;
   Esri::ArcGISRuntime::Point m_lastKnownLocation;
   bool m_isStarted = false;
+  double m_zOffset = 10.0;
+  Esri::ArcGISRuntime::SurfacePlacement m_surfacePlacement;
 
   QMetaObject::Connection m_positionErrorConnection;
   QMetaObject::Connection m_positionUpdateConnection;

--- a/Shared/build/arcgisruntime.pri
+++ b/Shared/build/arcgisruntime.pri
@@ -17,7 +17,7 @@
 CONFIG(deployment): DEFINES += DEPLOYMENT_BUILD
 
 # Run against the compiled toolkit.
-include($$PWD/../../arcgis-maps-sdk-toolkit-qt/uitools/toolkitcpp.pri)
+include($$PWD/../../arcgis-maps-sdk-toolkit-qt/uitools/toolkitcpp/toolkitcpp.pri)
 
 contains(QMAKE_HOST.os, Windows):{
   iniPath = $$(ALLUSERSPROFILE)\EsriRuntimeQt\ArcGIS Runtime SDK for Qt $${ARCGIS_RUNTIME_VERSION}.ini

--- a/Shared/configurations/ConfigurationController.cpp
+++ b/Shared/configurations/ConfigurationController.cpp
@@ -376,11 +376,12 @@ void ConfigurationController::fetchConfigurations()
 
     // check the folder recursively for other files
     QDirIterator dirIt(configurationDirectoryPath, QDir::Files | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
-    auto filesInConfigurationFolder = 0;
-    while (!dirIt.next().isEmpty())
+    uint8_t filesInConfigurationFolder = 0;
+    while (dirIt.hasNext())
     {
+      dirIt.next();
       filesInConfigurationFolder++;
-      if (filesInConfigurationFolder > 1)
+      if (filesInConfigurationFolder > 1) // stop checking once more than 1 file has been found in the directory
       {
         downloaded = true;
         break;

--- a/Shared/configurations/ConfigurationController.cpp
+++ b/Shared/configurations/ConfigurationController.cpp
@@ -376,12 +376,12 @@ void ConfigurationController::fetchConfigurations()
 
     // check the folder recursively for other files
     QDirIterator dirIt(configurationDirectoryPath, QDir::Files | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
-    uint8_t filesInConfigurationFolder = 0;
+    quint8 filesInConfigurationFolder = 0;
     while (dirIt.hasNext())
     {
       dirIt.next();
       filesInConfigurationFolder++;
-      if (filesInConfigurationFolder > 1) // stop checking once more than 1 file has been found in the directory
+      if (filesInConfigurationFolder > 1) // download is valid if more than one file is found
       {
         downloaded = true;
         break;


### PR DESCRIPTION
Configuration parameters have been added to the default configuration for a Z offset value and the scene SurfacePlacement property for the Location3d layer. Users can specify 'DrapedFlat' to always have the marker symbol drawn onto the terrain, Z offset will be ignored. Any other value will result in SurfacePlacement::Relative and the Z offset will be used for the offset value.

#365