### PR TITLE
Dtedder/minor cleanup

### DIFF
--- a/Handheld/Android/Android.pri
+++ b/Handheld/Android/Android.pri
@@ -29,4 +29,4 @@ DISTFILES += \
     $$PWD/gradlew \
     $$PWD/gradlew.bat
 
-ANDROID_ABIS = armeabi-v7a arm64-v8a x86
+ANDROID_ABIS = arm64-v8a

--- a/Handheld/Android/AndroidManifest.xml
+++ b/Handheld/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt" android:installLocation="auto" android:versionCode="-- %%INSERT_VERSION_CODE%% --" android:versionName="-- %%INSERT_VERSION_NAME%% --">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto" android:versionCode="-- %%INSERT_VERSION_CODE%% --" android:versionName="-- %%INSERT_VERSION_NAME%% --">
     <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true" android:smallScreens="true"/>
     <application android:name="org.qtproject.qt.android.bindings.QtApplication" android:hardwareAccelerated="true" android:label="-- %%INSERT_APP_NAME%% --" android:requestLegacyExternalStorage="true" android:allowNativeHeapPointerTagging="false" android:allowBackup="true" android:fullBackupOnly="false" android:icon="@drawable/icon">
         <activity android:name="org.qtproject.qt.android.bindings.QtActivity" android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density" android:label="-- %%INSERT_APP_NAME%% --" android:launchMode="singleTop" android:screenOrientation="unspecified" android:exported="true">

--- a/Handheld/Android/build.gradle
+++ b/Handheld/Android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:8.4.2'
     }
 }
 
@@ -34,6 +34,7 @@ android {
      * Changing them manually might break the compilation!
      *******************************************************/
 
+    namespace = "com.esri.arcgisruntime.opensourceapps.DSA_Handheld_Qt"
     compileSdkVersion androidCompileSdkVersion
     buildToolsVersion androidBuildToolsVersion
     ndkVersion androidNdkVersion
@@ -59,8 +60,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     lintOptions {

--- a/Handheld/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Handheld/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Shared/configurations/Configuration.h
+++ b/Shared/configurations/Configuration.h
@@ -30,11 +30,6 @@ public:
                 bool selected,
                 bool loaded,
                 int percentDownloaded);
-  Configuration() = default;
-  Configuration(const Configuration&) = default;
-  Configuration(Configuration&&) = default;
-  Configuration& operator=(const Configuration&) = default;
-  Configuration& operator=(Configuration&&) = default;
 
   QString name() const;
   void setName(const QString& name);

--- a/Shared/configurations/Configuration.h
+++ b/Shared/configurations/Configuration.h
@@ -30,7 +30,7 @@ public:
                 bool selected,
                 bool loaded,
                 int percentDownloaded);
-  Configuration(Configuration&) = default;
+  Configuration() = default;
   Configuration(const Configuration&) = default;
   Configuration(Configuration&&) = default;
   Configuration& operator=(const Configuration&) = default;

--- a/Vehicle/Android/Android.pri
+++ b/Vehicle/Android/Android.pri
@@ -29,4 +29,4 @@ DISTFILES += \
     $$PWD/gradlew \
     $$PWD/gradlew.bat
 
-ANDROID_ABIS = armeabi-v7a arm64-v8a x86
+ANDROID_ABIS = arm64-v8a

--- a/Vehicle/Android/AndroidManifest.xml
+++ b/Vehicle/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt" android:installLocation="auto" android:versionCode="-- %%INSERT_VERSION_CODE%% --" android:versionName="-- %%INSERT_VERSION_NAME%% --">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto" android:versionCode="-- %%INSERT_VERSION_CODE%% --" android:versionName="-- %%INSERT_VERSION_NAME%% --">
     <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true" android:smallScreens="true"/>
     <application android:name="org.qtproject.qt.android.bindings.QtApplication" android:hardwareAccelerated="true" android:label="-- %%INSERT_APP_NAME%% --" android:requestLegacyExternalStorage="true" android:allowNativeHeapPointerTagging="false" android:allowBackup="true" android:fullBackupOnly="false" android:icon="@drawable/icon">
         <activity android:name="org.qtproject.qt.android.bindings.QtActivity" android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density" android:label="-- %%INSERT_APP_NAME%% --" android:launchMode="singleTop" android:screenOrientation="unspecified" android:exported="true">

--- a/Vehicle/Android/build.gradle
+++ b/Vehicle/Android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:8.4.2'
     }
 }
 
@@ -34,6 +34,7 @@ android {
      * Changing them manually might break the compilation!
      *******************************************************/
 
+    namespace = "com.esri.arcgisruntime.opensourceapps.DSA_Vehicle_Qt"
     compileSdkVersion androidCompileSdkVersion
     buildToolsVersion androidBuildToolsVersion
     ndkVersion androidNdkVersion
@@ -59,8 +60,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     lintOptions {

--- a/Vehicle/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Vehicle/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Did some cleanup of the Android specific project files. Including removing architectures other than `arm64-v8a`.

Also fixed the typo in the default constructor for `Configuration` giving the warning.

#431