### PR TITLE
Dtedder/390 fix elevation source loading

### DIFF
--- a/Shared/LocationTextController.h
+++ b/Shared/LocationTextController.h
@@ -57,9 +57,11 @@ signals:
 private slots:
   void onGeoViewChanged();
   void onLocationChanged(const Esri::ArcGISRuntime::Point& pt);
+  void onToolAdded(AbstractTool* newTool);
 
 private:
   std::function<QString(const Esri::ArcGISRuntime::Point&)> formatCoordinate;
+  QMetaObject::Connection m_conToolAdded;
 
   QString currentLocationText() const;
   QString currentElevationText() const;


### PR DESCRIPTION
fix issue with surface pointer not getting updated if the app is started with an elevation source in the config file that is not valid.