### PR TITLE
Fix for Follow option missing for DynamicEntities/MessageFeeds

### DIFF
--- a/MessageSimulator/qml/main.qml
+++ b/MessageSimulator/qml/main.qml
@@ -44,7 +44,7 @@ ApplicationWindow {
             }
         }
 
-        onErrorOccurred: {
+        onErrorOccurred: (error) => {
             loggingPage.loggingText += "\n" + error;
         }
     }

--- a/Shared/ContextMenuController.cpp
+++ b/Shared/ContextMenuController.cpp
@@ -271,8 +271,10 @@ void ContextMenuController::processGeoElements()
     for (const auto* geoElement : geoElements)
     {
       if (geoElement->geometry().geometryType() == GeometryType::Point)
+      {
         if (++pointGeoElementCount > 1)
           break;
+      }
     }
 
     // no need to continue searching the results if more than

--- a/Shared/ContextMenuController.h
+++ b/Shared/ContextMenuController.h
@@ -99,8 +99,7 @@ private:
   QString m_resultTitle;
   Esri::ArcGISRuntime::Point m_contextLocation;
   Esri::ArcGISRuntime::Point m_contextBaseSurfaceLocation;
-  QHash<QString, QList<Esri::ArcGISRuntime::GeoElement*>> m_contextFeatures;
-  QHash<QString, QList<Esri::ArcGISRuntime::GeoElement*>> m_contextGraphics;
+  QHash<QString, QList<Esri::ArcGISRuntime::GeoElement*>> m_contextGeoElements;
 };
 
 } // Dsa

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -38,6 +38,7 @@
 
 // DSA headers
 #include "DsaUtility.h"
+#include "FollowPositionController.h"
 #include "ToolManager.h"
 #include "ToolResourceProvider.h"
 
@@ -113,11 +114,14 @@ void NavigationController::updateGeoView()
  */
 void NavigationController::zoomToInitialLocation()
 {
-  Viewpoint initViewpoint;
-  if (m_is3d)
-  {
-    m_sceneView->setViewpointAsync(m_sceneView->arcGISScene()->initialViewpoint(), 1.0f);
-  }
+  if (!m_is3d)
+    return;
+
+  // stop following if the home button is clicked
+  if (auto* followPositionController = ToolManager::instance().tool<FollowPositionController>(); followPositionController)
+    followPositionController->setFollowMode(FollowPositionController::FollowMode::Disabled);
+
+  m_sceneView->setViewpointAsync(m_sceneView->arcGISScene()->initialViewpoint(), 1.0f);
 }
 
 /*!

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -38,7 +38,6 @@
 
 // DSA headers
 #include "DsaUtility.h"
-#include "FollowPositionController.h"
 #include "ToolManager.h"
 #include "ToolResourceProvider.h"
 
@@ -116,10 +115,6 @@ void NavigationController::zoomToInitialLocation()
 {
   if (!m_is3d)
     return;
-
-  // stop following if the home button is clicked
-  if (auto* followPositionController = ToolManager::instance().tool<FollowPositionController>(); followPositionController)
-    followPositionController->setFollowMode(FollowPositionController::FollowMode::Disabled);
 
   m_sceneView->setViewpointAsync(m_sceneView->arcGISScene()->initialViewpoint(), 1.0f);
 }

--- a/Shared/qml/NavigationTool.qml
+++ b/Shared/qml/NavigationTool.qml
@@ -53,6 +53,7 @@ Item {
         OverlayButton {
             iconUrl: DsaResources.iconHome
             onClicked: {
+                followHud.stopFollowing();
                 navController.zoomToInitialLocation();
             }
         }


### PR DESCRIPTION
combine all IdentifyResults into one property
simplify the assigning of contextmenu options in the identify results. search for points only until more than 1 GeoElement of type point is found. fix clazy warnings for non-const containers in range based for-loops