### PR TITLE
Use model properties for selected basemap

### DIFF
--- a/Shared/BasemapPickerController.cpp
+++ b/Shared/BasemapPickerController.cpp
@@ -21,6 +21,7 @@
 #include "BasemapPickerController.h"
 
 // dsa app headers
+#include "TileCache.h"
 #include "TileCacheListModel.h"
 
 // toolkit headers
@@ -160,6 +161,10 @@ void BasemapPickerController::basemapSelected(int row)
   TileCache* tileCache = m_tileCacheModel->tileCacheAt(row);
   if (!tileCache)
     return;
+
+  m_selectedBasemapIndex = row;
+  m_selectedBasemapPath = tileCache->path();
+  emit selectedBasemapIndexChanged();
 
   Basemap* selectedBasemap = new Basemap(new ArcGISTiledLayer(tileCache, this), this);
   connect(selectedBasemap, &Basemap::errorOccurred, this, &BasemapPickerController::errorOccurred);

--- a/Shared/BasemapPickerController.h
+++ b/Shared/BasemapPickerController.h
@@ -82,7 +82,7 @@ private:
   QString             m_basemapDataPath;
   QString             m_defaultBasemap = "topographic";
   int                 m_selectedBasemapIndex = -1;
-  QString             m_selectedBasemapPath = "";
+  QString             m_selectedBasemapPath;
 
 private:
   void findBasemaps();

--- a/Shared/BasemapPickerController.h
+++ b/Shared/BasemapPickerController.h
@@ -41,6 +41,8 @@ class BasemapPickerController : public AbstractTool
   Q_OBJECT
 
   Q_PROPERTY(QAbstractListModel* tileCacheModel READ tileCacheModel NOTIFY tileCacheModelChanged)
+  Q_PROPERTY(int selectedBasemapIndex READ selectedBasemapIndex NOTIFY selectedBasemapIndexChanged)
+  Q_PROPERTY(QString selectedBasemapPath READ selectedBasemapPath NOTIFY selectedBasemapIndexChanged)
 
 public:
   static const QString DEFAULT_BASEMAP_PROPERTYNAME;
@@ -61,6 +63,8 @@ public:
   void setBasemapDataPath(const QString& dataPath);
   QString defaultBasemap() const { return m_defaultBasemap; }
   void setDefaultBasemap(const QString& defaultBasemap);
+  int selectedBasemapIndex() const { return m_selectedBasemapIndex; }
+  QString selectedBasemapPath() const { return m_selectedBasemapPath; }
 
 public slots:
   void onBasemapDataPathChanged();
@@ -70,12 +74,15 @@ signals:
   void basemapsDataPathChanged();
   void basemapChanged(Esri::ArcGISRuntime::Basemap* basemap, QString name = "");
   void toolErrorOccurred(const QString& errorMessage, const QString& additionalMessage);
+  void selectedBasemapIndexChanged();
 
 private:
   TileCacheListModel* m_tileCacheModel;
   int                 m_defaultBasemapIndex = 0;
   QString             m_basemapDataPath;
   QString             m_defaultBasemap = "topographic";
+  int                 m_selectedBasemapIndex = -1;
+  QString             m_selectedBasemapPath = "";
 
 private:
   void findBasemaps();

--- a/Shared/qml/BasemapPicker.qml
+++ b/Shared/qml/BasemapPicker.qml
@@ -38,8 +38,8 @@ DsaPanel {
             width: basemapsList.cellWidth - 10 * scaleFactor
             height: basemapsList.cellHeight - 10 * scaleFactor
 
-            border.color: index === basemapsList.currentIndex ? Material.accent : Material.background
-            border.width: index === basemapsList.currentIndex ? 2 * scaleFactor : 1 * scaleFactor
+            border.color: index === toolController.selectedBasemapIndex ? Material.accent : Material.background
+            border.width: index === toolController.selectedBasemapIndex ? 2 * scaleFactor : 1 * scaleFactor
             color: Material.background
             radius: 2 * scaleFactor
 
@@ -76,26 +76,19 @@ DsaPanel {
 
             MouseArea {
                 anchors.fill: parent
-                hoverEnabled: true
                 onClicked: {
-                    toolController.basemapSelected(index);
-                    basemapSelected();
-                }
-                onHoveredChanged: {
-                    if (containsMouse) {
-                        basemapsList.currentIndex = index
-                        basemapsList.currentPath = path
+                    if (index !== toolController.selectedBasemapIndex)
+                    {
+                        toolController.basemapSelected(index);
+                        basemapSelected();
                     }
                 }
-
             }
         }
     }
 
     GridView {
         id: basemapsList
-
-        property string currentPath: ""
 
         anchors{
             top: titleBar.bottom
@@ -110,6 +103,7 @@ DsaPanel {
         cellWidth: 128 * scaleFactor
         cellHeight: 128 * scaleFactor
         width: 2 * cellWidth
+        currentIndex: toolController.selectedBasemapIndex
 
         delegate: tileCacheDelegate
     }
@@ -129,7 +123,7 @@ DsaPanel {
         Label {
             id: pathText
             anchors.fill: parent
-            text: basemapsList.currentPath
+            text: toolController.selectedBasemapPath
             wrapMode: Text.WrapAnywhere
             elide: Text.ElideRight
             font.pixelSize: 12 * scaleFactor

--- a/Shared/qml/BasemapPicker.qml
+++ b/Shared/qml/BasemapPicker.qml
@@ -77,8 +77,7 @@ DsaPanel {
             MouseArea {
                 anchors.fill: parent
                 onClicked: {
-                    if (index !== toolController.selectedBasemapIndex)
-                    {
+                    if (index !== toolController.selectedBasemapIndex) {
                         toolController.basemapSelected(index);
                         basemapSelected();
                     }


### PR DESCRIPTION
Existing GridView was using hover mouse event to switch the currentIndex which was leading to the unexpected behavior in the associated issue. The currentIndex is now bound to the selected basemap's index which is updated on the controller on mouse click. There is also a new property for the path (value updated along with index) that is bound in the footer text element instead of the QML property that was used before.