### PR TITLE
Isolate setProperties to only those associated with a tool

### DIFF
--- a/Shared/AbstractTool.cpp
+++ b/Shared/AbstractTool.cpp
@@ -16,10 +16,14 @@
 
 #include "AbstractTool.h"
 
+// STL headers
+#include <algorithm>
+
 using namespace Esri::ArcGISRuntime;
 
 namespace Dsa
 {
+
 /*!
   \class Dsa::AbstractTool
   \inmodule ArcGISQtToolkit
@@ -106,6 +110,11 @@ void AbstractTool::setActive(bool active)
 bool AbstractTool::isActive() const
 {
   return m_active;
+}
+
+bool AbstractTool::setContainsString(const std::unordered_set<QString>& strSet, const QString& str)
+{
+  return std::any_of(std::cbegin(strSet), std::end(strSet), [str](const QString& p) { return str == p; });
 }
 
 // Signals

--- a/Shared/AbstractTool.cpp
+++ b/Shared/AbstractTool.cpp
@@ -76,6 +76,11 @@ void AbstractTool::setProperties(const QVariantMap&)
 
 }
 
+void AbstractTool::setProperty(const QString&, const QVariantMap&)
+{
+
+}
+
 /*!
    \brief Sets whether this tool is active to \a active.
 

--- a/Shared/AbstractTool.cpp
+++ b/Shared/AbstractTool.cpp
@@ -71,14 +71,18 @@ bool AbstractTool::handleClick(const Point& pos)
   and the value is a QVariant. Properties are useful for general settings
   which you wish to persist for the tool, such as default modes.
  */
-void AbstractTool::setProperties(const QVariantMap&)
+void AbstractTool::toolInitProperties(const QVariantMap&)
 {
-
 }
 
-void AbstractTool::setProperty(const QString&, const QVariantMap&)
+/*
+ * Derived tools should override this method to implement logic that
+ * will determine whether or not the tool's setProperties method should
+ * be invoked again to re-initialize the tool when a property changes.
+ */
+bool AbstractTool::shouldSetProperties(const QString&)
 {
-
+  return false;
 }
 
 /*!

--- a/Shared/AbstractTool.h
+++ b/Shared/AbstractTool.h
@@ -43,8 +43,8 @@ public:
   virtual QString toolName() const = 0;
   virtual bool handleClick(const Esri::ArcGISRuntime::Point& pos);
 
-  virtual void setProperties(const QVariantMap& properties);
-  virtual void setProperty(const QString& propertyName, const QVariantMap& properties);
+  virtual void toolInitProperties(const QVariantMap& properties);
+  virtual bool shouldSetProperties(const QString& propertyName);
 
   virtual void setActive(bool active);
   bool isActive() const;

--- a/Shared/AbstractTool.h
+++ b/Shared/AbstractTool.h
@@ -17,9 +17,13 @@
 #ifndef ABSTRACT_TOOL_H
 #define ABSTRACT_TOOL_H
 
+// Qt headers
 #include <QObject>
 #include <QString>
 #include <QVariantMap>
+
+// STL headers
+#include <unordered_set>
 
 namespace Esri::ArcGISRuntime {
   class Error;
@@ -56,6 +60,7 @@ signals:
 
 protected:
   bool m_active = false;
+  static bool setContainsString(const std::unordered_set<QString>& strSet, const QString& str);
 };
 
 } // Toolkit

--- a/Shared/AbstractTool.h
+++ b/Shared/AbstractTool.h
@@ -44,6 +44,7 @@ public:
   virtual bool handleClick(const Esri::ArcGISRuntime::Point& pos);
 
   virtual void setProperties(const QVariantMap& properties);
+  virtual void setProperty(const QString& propertyName, const QVariantMap& properties);
 
   virtual void setActive(bool active);
   bool isActive() const;

--- a/Shared/AddLocalDataController.cpp
+++ b/Shared/AddLocalDataController.cpp
@@ -904,6 +904,12 @@ void AddLocalDataController::setProperties(const QVariantMap& properties)
   refreshLocalDataModel();
 }
 
+void AddLocalDataController::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == LOCAL_DATAPATHS_PROPERTYNAME)
+    setProperties(properties);
+}
+
 } // Dsa
 
 // Signal Documentation

--- a/Shared/AddLocalDataController.cpp
+++ b/Shared/AddLocalDataController.cpp
@@ -879,7 +879,7 @@ QString AddLocalDataController::toolName() const
 /*
  \brief Sets \a properties, such as the directories to search for local data.
 */
-void AddLocalDataController::setProperties(const QVariantMap& properties)
+void AddLocalDataController::toolInitProperties(const QVariantMap& properties)
 {
   const QStringList filePaths = properties[LOCAL_DATAPATHS_PROPERTYNAME].toStringList();
   if (filePaths.empty())
@@ -904,10 +904,9 @@ void AddLocalDataController::setProperties(const QVariantMap& properties)
   refreshLocalDataModel();
 }
 
-void AddLocalDataController::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool AddLocalDataController::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == LOCAL_DATAPATHS_PROPERTYNAME)
-    setProperties(properties);
+  return (propertyName == LOCAL_DATAPATHS_PROPERTYNAME);
 }
 
 } // Dsa

--- a/Shared/AddLocalDataController.h
+++ b/Shared/AddLocalDataController.h
@@ -54,8 +54,7 @@ public:
   QAbstractListModel* localDataModel() const;
 
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   // helpers for creating the layers for a given string
   void createFeatureLayerGeodatabase(const QString& path);
@@ -83,6 +82,7 @@ signals:
   void toolErrorOccurred(const QString& errorMessage, const QString& additionalMessage);
 
 private:
+  void toolInitProperties(const QVariantMap& properties) override;
   QStringList determineFileFilters(const QString& fileType);
   QStringList fileFilterList() const { return m_fileFilterList; }
   static const QString allData() { return s_allData; }

--- a/Shared/AddLocalDataController.h
+++ b/Shared/AddLocalDataController.h
@@ -55,6 +55,7 @@ public:
 
   QString toolName() const override;
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   // helpers for creating the layers for a given string
   void createFeatureLayerGeodatabase(const QString& path);

--- a/Shared/AddLocalDataController.h
+++ b/Shared/AddLocalDataController.h
@@ -54,6 +54,7 @@ public:
   QAbstractListModel* localDataModel() const;
 
   QString toolName() const override;
+  void toolInitProperties(const QVariantMap& properties) override;
   bool shouldSetProperties(const QString& propertyName) override;
 
   // helpers for creating the layers for a given string
@@ -82,7 +83,6 @@ signals:
   void toolErrorOccurred(const QString& errorMessage, const QString& additionalMessage);
 
 private:
-  void toolInitProperties(const QVariantMap& properties) override;
   QStringList determineFileFilters(const QString& fileType);
   QStringList fileFilterList() const { return m_fileFilterList; }
   static const QString allData() { return s_allData; }

--- a/Shared/BasemapPickerController.cpp
+++ b/Shared/BasemapPickerController.cpp
@@ -202,7 +202,7 @@ QString BasemapPickerController::toolName() const
  *  \li BasemapDirectory. The directory containing basemap data.
  * \endlist
  */
-void BasemapPickerController::setProperties(const QVariantMap& properties)
+void BasemapPickerController::toolInitProperties(const QVariantMap& properties)
 {
   const QString newDefaultBasemap = properties.value(DEFAULT_BASEMAP_PROPERTYNAME).toString();
   const bool basemapChanged = !newDefaultBasemap.isEmpty() && newDefaultBasemap != m_defaultBasemap;
@@ -221,11 +221,10 @@ void BasemapPickerController::setProperties(const QVariantMap& properties)
   }
 }
 
-void BasemapPickerController::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool BasemapPickerController::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == DEFAULT_BASEMAP_PROPERTYNAME ||
-      propertyName == BASEMAP_DIRECTORY_PROPERTYNAME)
-    setProperties(properties);
+  return (propertyName == DEFAULT_BASEMAP_PROPERTYNAME ||
+          propertyName == BASEMAP_DIRECTORY_PROPERTYNAME);
 }
 
 } // Dsa

--- a/Shared/BasemapPickerController.cpp
+++ b/Shared/BasemapPickerController.cpp
@@ -221,6 +221,13 @@ void BasemapPickerController::setProperties(const QVariantMap& properties)
   }
 }
 
+void BasemapPickerController::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == DEFAULT_BASEMAP_PROPERTYNAME ||
+      propertyName == BASEMAP_DIRECTORY_PROPERTYNAME)
+    setProperties(properties);
+}
+
 } // Dsa
 
 // Signal Documentation

--- a/Shared/BasemapPickerController.h
+++ b/Shared/BasemapPickerController.h
@@ -58,6 +58,7 @@ public:
 
   QString toolName() const override;
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   QString basemapDataPath() const { return m_basemapDataPath; }
   void setBasemapDataPath(const QString& dataPath);

--- a/Shared/BasemapPickerController.h
+++ b/Shared/BasemapPickerController.h
@@ -57,8 +57,8 @@ public:
   Q_INVOKABLE void selectInitialBasemap();
 
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   QString basemapDataPath() const { return m_basemapDataPath; }
   void setBasemapDataPath(const QString& dataPath);

--- a/Shared/CoordinateConversionToolProxy.cpp
+++ b/Shared/CoordinateConversionToolProxy.cpp
@@ -139,6 +139,12 @@ void CoordinateConversionToolProxy::setProperties(const QVariantMap& properties)
   }
 }
 
+void CoordinateConversionToolProxy::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == QStringLiteral("CoordinateFormat"))
+    setProperties(properties);
+}
+
 /*!
  * \brief Returns a controller that is fed with DSA and GeoView updates when
  * applicable.

--- a/Shared/CoordinateConversionToolProxy.cpp
+++ b/Shared/CoordinateConversionToolProxy.cpp
@@ -116,7 +116,7 @@ void CoordinateConversionToolProxy::setInInputMode(bool mode)
  * configuration data read from JSON. Here we do a lookup of all formats and
  * apply the one with the matching name to our inputFormat result object.
  */
-void CoordinateConversionToolProxy::setProperties(const QVariantMap& properties)
+void CoordinateConversionToolProxy::toolInitProperties(const QVariantMap& properties)
 {
   const auto formats = m_controller->coordinateFormats();
   if (!formats)
@@ -139,10 +139,9 @@ void CoordinateConversionToolProxy::setProperties(const QVariantMap& properties)
   }
 }
 
-void CoordinateConversionToolProxy::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool CoordinateConversionToolProxy::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == QStringLiteral("CoordinateFormat"))
-    setProperties(properties);
+  return (propertyName == QStringLiteral("CoordinateFormat"));
 }
 
 /*!

--- a/Shared/CoordinateConversionToolProxy.h
+++ b/Shared/CoordinateConversionToolProxy.h
@@ -46,6 +46,7 @@ public:
   bool handleClick(const Esri::ArcGISRuntime::Point& pos) override;
 
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   Esri::ArcGISRuntime::Toolkit::CoordinateConversionController* controller() const;
 

--- a/Shared/CoordinateConversionToolProxy.h
+++ b/Shared/CoordinateConversionToolProxy.h
@@ -45,8 +45,8 @@ public:
 
   bool handleClick(const Esri::ArcGISRuntime::Point& pos) override;
 
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   Esri::ArcGISRuntime::Toolkit::CoordinateConversionController* controller() const;
 

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -43,7 +43,6 @@
 #include <QSettings>
 
 // DSA headers
-#include "AddLocalDataController.h"
 #include "AlertConstants.h"
 #include "AppConstants.h"
 #include "BasemapPickerController.h"

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -292,7 +292,7 @@ void DsaController::onPropertyChanged(const QString& propertyName, const QVarian
 
     if (tool->shouldSetProperties(propertyName))
     {
-      disconnect(tool, &AbstractTool::propertyChanged,this, &DsaController::onPropertyChanged);
+      disconnect(tool, &AbstractTool::propertyChanged, this, &DsaController::onPropertyChanged);
       tool->toolInitProperties(m_dsaSettings);
       connect(tool, &AbstractTool::propertyChanged, this, &DsaController::onPropertyChanged);
     }

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -43,6 +43,7 @@
 #include <QSettings>
 
 // DSA headers
+#include "AddLocalDataController.h"
 #include "AlertConstants.h"
 #include "AppConstants.h"
 #include "BasemapPickerController.h"
@@ -151,7 +152,7 @@ void DsaController::init(GeoView* geoView)
   auto openScenePackageTool = ToolManager::instance().tool<OpenMobileScenePackageController>();
   if (openScenePackageTool)
   {
-    openScenePackageTool->setProperties(m_dsaSettings);
+    openScenePackageTool->toolInitProperties(m_dsaSettings);
     hasActiveScene = openScenePackageTool->hasActiveScene();
   }
 
@@ -184,7 +185,7 @@ void DsaController::init(GeoView* geoView)
     if (!abstractTool)
       continue;
 
-    abstractTool->setProperties(m_dsaSettings);
+    abstractTool->toolInitProperties(m_dsaSettings);
 
     connect(abstractTool, &AbstractTool::errorOccurred, this, &DsaController::onError);
     connect(abstractTool, &AbstractTool::propertyChanged, this, &DsaController::onPropertyChanged);
@@ -285,17 +286,17 @@ void DsaController::onPropertyChanged(const QString& propertyName, const QVarian
   saveSettings();
 
   // inform tools of the change
-  auto it = ToolManager::instance().begin();
-  auto itEnd = ToolManager::instance().end();
-  for (;it != itEnd; ++it)
+  for (auto* tool : ToolManager::instance())
   {
-    AbstractTool* tool = *it;
     if (!tool)
       continue;
 
-    disconnect(tool, &AbstractTool::propertyChanged,this, &DsaController::onPropertyChanged);
-    tool->setProperty(propertyName, m_dsaSettings);
-    connect(tool, &AbstractTool::propertyChanged, this, &DsaController::onPropertyChanged);
+    if (tool->shouldSetProperties(propertyName))
+    {
+      disconnect(tool, &AbstractTool::propertyChanged,this, &DsaController::onPropertyChanged);
+      tool->toolInitProperties(m_dsaSettings);
+      connect(tool, &AbstractTool::propertyChanged, this, &DsaController::onPropertyChanged);
+    }
   }
 }
 
@@ -336,7 +337,7 @@ void DsaController::resetToDefaultScene()
   onPropertyChanged(AppConstants::SCENEINDEX_PROPERTYNAME, -1);
   onPropertyChanged(AppConstants::CURRENTSCENE_PROPERTYNAME, "");
   onPropertyChanged(AppConstants::LAYERS_PROPERTYNAME, QJsonArray().toVariantList());
-  m_cacheManager->setProperties(m_dsaSettings);
+  m_cacheManager->toolInitProperties(m_dsaSettings);
 }
 
 /*!

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -294,7 +294,7 @@ void DsaController::onPropertyChanged(const QString& propertyName, const QVarian
       continue;
 
     disconnect(tool, &AbstractTool::propertyChanged,this, &DsaController::onPropertyChanged);
-    tool->setProperties(m_dsaSettings);
+    tool->setProperty(propertyName, m_dsaSettings);
     connect(tool, &AbstractTool::propertyChanged, this, &DsaController::onPropertyChanged);
   }
 }

--- a/Shared/GridController.cpp
+++ b/Shared/GridController.cpp
@@ -88,9 +88,15 @@ void GridController::toolInitProperties(const QVariantMap& properties)
 
 bool GridController::shouldSetProperties(const QString& propertyName)
 {
-  return (propertyName == PROPERTY_NAME_GRID_VISIBLE ||
-          propertyName == PROPERTY_NAME_GRID_COLOR_SCHEME ||
-          propertyName == QStringLiteral("CoordinateFormat"));
+  // list all property names that should cause the tool to re-initialize
+  static const std::unordered_set<QString> propertyNames
+  {
+    PROPERTY_NAME_GRID_VISIBLE,
+    PROPERTY_NAME_GRID_COLOR_SCHEME,
+    QStringLiteral("CoordinateFormat")
+  };
+
+  return setContainsString(propertyNames, propertyName);
 }
 
 bool GridController::gridVisible() const
@@ -118,7 +124,7 @@ void GridController::setGridColorScheme(const QString& gridColorScheme)
   m_gridColorScheme = gridColorScheme;
   m_gridColorSchemeIndex = m_gridColorSchemes.indexOf(m_gridColorScheme);
 
-  const static QHash<QString, QColor> gridLineColors
+  static const QHash<QString, QColor> gridLineColors
   {
     { GRID_COLOR_SCHEME_VALUE_DARK, QColorConstants::DarkGray },
     { GRID_COLOR_SCHEME_VALUE_LIGHT, QColorConstants::LightGray },

--- a/Shared/GridController.cpp
+++ b/Shared/GridController.cpp
@@ -58,7 +58,7 @@ QString GridController::toolName() const
   return "GridController";
 }
 
-void GridController::setProperties(const QVariantMap& properties)
+void GridController::toolInitProperties(const QVariantMap& properties)
 {
   // set the member variables to the values from the config file initially
   static bool initialized = false;
@@ -86,12 +86,11 @@ void GridController::setProperties(const QVariantMap& properties)
   setCoordinateFormat(properties["CoordinateFormat"].toString());
 }
 
-void GridController::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool GridController::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == PROPERTY_NAME_GRID_VISIBLE ||
-      propertyName == PROPERTY_NAME_GRID_COLOR_SCHEME ||
-      propertyName == QStringLiteral("CoordinateFormat"))
-    setProperties(properties);
+  return (propertyName == PROPERTY_NAME_GRID_VISIBLE ||
+          propertyName == PROPERTY_NAME_GRID_COLOR_SCHEME ||
+          propertyName == QStringLiteral("CoordinateFormat"));
 }
 
 bool GridController::gridVisible() const

--- a/Shared/GridController.cpp
+++ b/Shared/GridController.cpp
@@ -86,6 +86,14 @@ void GridController::setProperties(const QVariantMap& properties)
   setCoordinateFormat(properties["CoordinateFormat"].toString());
 }
 
+void GridController::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == PROPERTY_NAME_GRID_VISIBLE ||
+      propertyName == PROPERTY_NAME_GRID_COLOR_SCHEME ||
+      propertyName == QStringLiteral("CoordinateFormat"))
+    setProperties(properties);
+}
+
 bool GridController::gridVisible() const
 {
   return m_gridVisible;

--- a/Shared/GridController.h
+++ b/Shared/GridController.h
@@ -56,6 +56,7 @@ public:
 
   QString toolName() const override;
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   bool gridVisible() const;
   void setGridVisible(bool gridVisible);

--- a/Shared/GridController.h
+++ b/Shared/GridController.h
@@ -55,8 +55,8 @@ public:
   explicit GridController(QObject* parent = nullptr);
 
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   bool gridVisible() const;
   void setGridVisible(bool gridVisible);

--- a/Shared/LayerCacheManager.cpp
+++ b/Shared/LayerCacheManager.cpp
@@ -148,6 +148,13 @@ void LayerCacheManager::setProperties(const QVariantMap& properties)
   m_initialLoadCompleted = true;
 }
 
+void LayerCacheManager::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == LAYERS_PROPERTYNAME ||
+      propertyName == ELEVATION_PROPERTYNAME)
+    setProperties(properties);
+}
+
 /*!
  \brief Creates a Layer from the provided \a jsonObject and adds at the given \a layerIndex.
 

--- a/Shared/LayerCacheManager.cpp
+++ b/Shared/LayerCacheManager.cpp
@@ -131,7 +131,7 @@ QString LayerCacheManager::toolName() const
 /*!
  \brief Sets \a properties from the configuration file
  */
-void LayerCacheManager::setProperties(const QVariantMap& properties)
+void LayerCacheManager::toolInitProperties(const QVariantMap& properties)
 {
   if (m_initialLoadCompleted || !m_localDataController)
     return;
@@ -148,11 +148,10 @@ void LayerCacheManager::setProperties(const QVariantMap& properties)
   m_initialLoadCompleted = true;
 }
 
-void LayerCacheManager::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool LayerCacheManager::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == LAYERS_PROPERTYNAME ||
-      propertyName == ELEVATION_PROPERTYNAME)
-    setProperties(properties);
+  return (propertyName == LAYERS_PROPERTYNAME ||
+          propertyName == ELEVATION_PROPERTYNAME);
 }
 
 /*!

--- a/Shared/LayerCacheManager.h
+++ b/Shared/LayerCacheManager.h
@@ -43,6 +43,7 @@ public:
 
   QString toolName() const override;
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   void layerToJson(Esri::ArcGISRuntime::Layer* layer);
   void jsonToLayer(const QJsonObject& jsonObject, const int layerIndex = -1);

--- a/Shared/LayerCacheManager.h
+++ b/Shared/LayerCacheManager.h
@@ -42,8 +42,8 @@ public:
   ~LayerCacheManager();
 
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   void layerToJson(Esri::ArcGISRuntime::Layer* layer);
   void jsonToLayer(const QJsonObject& jsonObject, const int layerIndex = -1);

--- a/Shared/LocationController.cpp
+++ b/Shared/LocationController.cpp
@@ -224,6 +224,16 @@ void LocationController::setProperties(const QVariantMap& properties)
     m_locationDisplay3d->setSurfacePlacement(SurfacePlacement::Relative);
 }
 
+void LocationController::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == PROPERTY_NAME_SIMULATE_LOCATION ||
+      propertyName == PROPERTY_NAME_GPX_FILE ||
+      propertyName == PROPERTY_NAME_RESOURCE_DIRECTORY ||
+      propertyName == PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET ||
+      propertyName == PROPERTY_NAME_CURRENT_LOCATION_SURFACE_PLACEMENT)
+    setProperties(properties);
+}
+
 /*!
   \property LocationController::enabled
   \brief Returns whether the tool is enabled.

--- a/Shared/LocationController.cpp
+++ b/Shared/LocationController.cpp
@@ -226,11 +226,17 @@ void LocationController::toolInitProperties(const QVariantMap& properties)
 
 bool LocationController::shouldSetProperties(const QString& propertyName)
 {
-  return (propertyName == PROPERTY_NAME_SIMULATE_LOCATION ||
-          propertyName == PROPERTY_NAME_GPX_FILE ||
-          propertyName == PROPERTY_NAME_RESOURCE_DIRECTORY ||
-          propertyName == PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET ||
-          propertyName == PROPERTY_NAME_CURRENT_LOCATION_SURFACE_PLACEMENT);
+  // list all property names that should cause the tool to re-initialize
+  static const std::unordered_set<QString> propertyNames
+  {
+    PROPERTY_NAME_SIMULATE_LOCATION,
+    PROPERTY_NAME_GPX_FILE,
+    PROPERTY_NAME_RESOURCE_DIRECTORY,
+    PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET,
+    PROPERTY_NAME_CURRENT_LOCATION_SURFACE_PLACEMENT
+  };
+
+  return setContainsString(propertyNames, propertyName);
 }
 
 /*!

--- a/Shared/LocationController.cpp
+++ b/Shared/LocationController.cpp
@@ -200,7 +200,7 @@ QString LocationController::toolName() const
  *  \li \c ResourceDirectory - The directory containing icons for the location display.
  * \endlist
  */
-void LocationController::setProperties(const QVariantMap& properties)
+void LocationController::toolInitProperties(const QVariantMap& properties)
 {
   // setup simulation from the configuration properties
   const bool simulate = QString::compare(properties[PROPERTY_NAME_SIMULATE_LOCATION].toString(), QStringLiteral("true"), Qt::CaseInsensitive) == 0;
@@ -224,14 +224,13 @@ void LocationController::setProperties(const QVariantMap& properties)
     m_locationDisplay3d->setSurfacePlacement(SurfacePlacement::Relative);
 }
 
-void LocationController::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool LocationController::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == PROPERTY_NAME_SIMULATE_LOCATION ||
-      propertyName == PROPERTY_NAME_GPX_FILE ||
-      propertyName == PROPERTY_NAME_RESOURCE_DIRECTORY ||
-      propertyName == PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET ||
-      propertyName == PROPERTY_NAME_CURRENT_LOCATION_SURFACE_PLACEMENT)
-    setProperties(properties);
+  return (propertyName == PROPERTY_NAME_SIMULATE_LOCATION ||
+          propertyName == PROPERTY_NAME_GPX_FILE ||
+          propertyName == PROPERTY_NAME_RESOURCE_DIRECTORY ||
+          propertyName == PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET ||
+          propertyName == PROPERTY_NAME_CURRENT_LOCATION_SURFACE_PLACEMENT);
 }
 
 /*!

--- a/Shared/LocationController.h
+++ b/Shared/LocationController.h
@@ -60,6 +60,7 @@ public:
 
   QString toolName() const override;
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   bool isEnabled() const;
   void setEnabled(bool isEnabled);

--- a/Shared/LocationController.h
+++ b/Shared/LocationController.h
@@ -59,8 +59,8 @@ public:
   ~LocationController();
 
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   bool isEnabled() const;
   void setEnabled(bool isEnabled);

--- a/Shared/LocationTextController.cpp
+++ b/Shared/LocationTextController.cpp
@@ -189,6 +189,14 @@ void LocationTextController::setProperties(const QVariantMap& properties)
   setUnitOfMeasurement(properties[UNIT_OF_MEASUREMENT_PROPERTYNAME].toString());
 }
 
+void LocationTextController::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == COORDINATE_FORMAT_PROPERTYNAME ||
+      propertyName == USE_GPS_PROPERTYNAME ||
+      propertyName == UNIT_OF_MEASUREMENT_PROPERTYNAME)
+    setProperties(properties);
+}
+
 /*!
  \brief Changes the coordinate \a format.
  */

--- a/Shared/LocationTextController.cpp
+++ b/Shared/LocationTextController.cpp
@@ -182,19 +182,18 @@ void LocationTextController::onGeoViewChanged()
 /*!
  \brief Set \a properties from the configuration file.
  */
-void LocationTextController::setProperties(const QVariantMap& properties)
+void LocationTextController::toolInitProperties(const QVariantMap& properties)
 {
   setCoordinateFormat(properties[COORDINATE_FORMAT_PROPERTYNAME].toString());
   setUseGpsForElevation(properties[USE_GPS_PROPERTYNAME].toBool());
   setUnitOfMeasurement(properties[UNIT_OF_MEASUREMENT_PROPERTYNAME].toString());
 }
 
-void LocationTextController::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool LocationTextController::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == COORDINATE_FORMAT_PROPERTYNAME ||
-      propertyName == USE_GPS_PROPERTYNAME ||
-      propertyName == UNIT_OF_MEASUREMENT_PROPERTYNAME)
-    setProperties(properties);
+  return (propertyName == COORDINATE_FORMAT_PROPERTYNAME ||
+          propertyName == USE_GPS_PROPERTYNAME ||
+          propertyName == UNIT_OF_MEASUREMENT_PROPERTYNAME);
 }
 
 /*!

--- a/Shared/LocationTextController.cpp
+++ b/Shared/LocationTextController.cpp
@@ -191,9 +191,15 @@ void LocationTextController::toolInitProperties(const QVariantMap& properties)
 
 bool LocationTextController::shouldSetProperties(const QString& propertyName)
 {
-  return (propertyName == COORDINATE_FORMAT_PROPERTYNAME ||
-          propertyName == USE_GPS_PROPERTYNAME ||
-          propertyName == UNIT_OF_MEASUREMENT_PROPERTYNAME);
+  // list all property names that should cause the tool to re-initialize
+  static const std::unordered_set<QString> propertyNames
+  {
+    COORDINATE_FORMAT_PROPERTYNAME,
+    USE_GPS_PROPERTYNAME,
+    UNIT_OF_MEASUREMENT_PROPERTYNAME
+  };
+
+  return setContainsString(propertyNames, propertyName);
 }
 
 /*!

--- a/Shared/LocationTextController.h
+++ b/Shared/LocationTextController.h
@@ -39,8 +39,8 @@ public:
   ~LocationTextController();
 
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
   void setCoordinateFormat(const QString& format);
   QString coordinateFormat() const;
   void setUnitOfMeasurement(const QString& unit);

--- a/Shared/LocationTextController.h
+++ b/Shared/LocationTextController.h
@@ -40,6 +40,7 @@ public:
 
   QString toolName() const override;
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
   void setCoordinateFormat(const QString& format);
   QString coordinateFormat() const;
   void setUnitOfMeasurement(const QString& unit);

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -81,13 +81,6 @@ QString NavigationController::toolName() const
 }
 
 /*!
- * \brief Sets any values in \a properties which are relevant for the navigation controller.
- */
-void NavigationController::setProperties(const QVariantMap&)
-{
-}
-
-/*!
   \internal
  */
 void NavigationController::updateGeoView()

--- a/Shared/NavigationController.h
+++ b/Shared/NavigationController.h
@@ -52,7 +52,6 @@ public:
   Q_INVOKABLE void set2D();
 
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
 
   bool isVertical() const;
   double zoomFactor() const;

--- a/Shared/OptionsController.cpp
+++ b/Shared/OptionsController.cpp
@@ -171,6 +171,14 @@ void OptionsController::setProperties(const QVariantMap& properties)
   getUpdatedTools();
 }
 
+void OptionsController::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == QStringLiteral("CoordinateFormat") ||
+      propertyName == AppConstants::UNIT_OF_MEASUREMENT_PROPERTYNAME ||
+      propertyName == AppConstants::USERNAME_PROPERTYNAME)
+    setProperties(properties);
+}
+
 /*!
  \property OptionsController::coordinateFormats
  \brief Returns the coordinate format list for display in the combo box.

--- a/Shared/OptionsController.cpp
+++ b/Shared/OptionsController.cpp
@@ -173,9 +173,15 @@ void OptionsController::toolInitProperties(const QVariantMap& properties)
 
 bool OptionsController::shouldSetProperties(const QString& propertyName)
 {
-  return (propertyName == QStringLiteral("CoordinateFormat") ||
-          propertyName == AppConstants::UNIT_OF_MEASUREMENT_PROPERTYNAME ||
-          propertyName == AppConstants::USERNAME_PROPERTYNAME);
+  // list all property names that should cause the tool to re-initialize
+  static const std::unordered_set<QString> propertyNames
+  {
+    QStringLiteral("CoordinateFormat"),
+    AppConstants::UNIT_OF_MEASUREMENT_PROPERTYNAME,
+    AppConstants::USERNAME_PROPERTYNAME
+  };
+
+  return setContainsString(propertyNames, propertyName);
 }
 
 /*!

--- a/Shared/OptionsController.cpp
+++ b/Shared/OptionsController.cpp
@@ -146,7 +146,7 @@ QString OptionsController::toolName() const
 /*!
  \brief Sets \a properties from the configuration file.
  */
-void OptionsController::setProperties(const QVariantMap& properties)
+void OptionsController::toolInitProperties(const QVariantMap& properties)
 {
   // access tool properties from the config
   m_coordinateFormat = properties["CoordinateFormat"].toString();
@@ -171,12 +171,11 @@ void OptionsController::setProperties(const QVariantMap& properties)
   getUpdatedTools();
 }
 
-void OptionsController::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool OptionsController::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == QStringLiteral("CoordinateFormat") ||
-      propertyName == AppConstants::UNIT_OF_MEASUREMENT_PROPERTYNAME ||
-      propertyName == AppConstants::USERNAME_PROPERTYNAME)
-    setProperties(properties);
+  return (propertyName == QStringLiteral("CoordinateFormat") ||
+          propertyName == AppConstants::UNIT_OF_MEASUREMENT_PROPERTYNAME ||
+          propertyName == AppConstants::USERNAME_PROPERTYNAME);
 }
 
 /*!

--- a/Shared/OptionsController.h
+++ b/Shared/OptionsController.h
@@ -49,6 +49,7 @@ public:
 
   QString toolName() const override;
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
   Q_INVOKABLE void setCoordinateFormat(const QString& format);
   Q_INVOKABLE void setUnitOfMeasurement(const QString& unit);
 

--- a/Shared/OptionsController.h
+++ b/Shared/OptionsController.h
@@ -48,8 +48,8 @@ public:
   ~OptionsController();
 
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
   Q_INVOKABLE void setCoordinateFormat(const QString& format);
   Q_INVOKABLE void setUnitOfMeasurement(const QString& unit);
 

--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -146,7 +146,7 @@ QString AlertConditionsController::toolName() const
  *  \li MessageFeeds. A list of real-time feeds to be used as condition sources.
  * \endlist
  */
-void AlertConditionsController::setProperties(const QVariantMap& properties)
+void AlertConditionsController::toolInitProperties(const QVariantMap& properties)
 {
   const auto conditionsData = properties[AlertConstants::ALERT_CONDITIONS_PROPERTYNAME];
 
@@ -203,11 +203,10 @@ void AlertConditionsController::setProperties(const QVariantMap& properties)
   addStoredConditions();
 }
 
-void AlertConditionsController::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool AlertConditionsController::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == AlertConstants::ALERT_CONDITIONS_PROPERTYNAME ||
-      propertyName == MessageFeedConstants::MESSAGE_FEEDS_PROPERTYNAME)
-    setProperties(properties);
+  return (propertyName == AlertConstants::ALERT_CONDITIONS_PROPERTYNAME ||
+          propertyName == MessageFeedConstants::MESSAGE_FEEDS_PROPERTYNAME);
 }
 
 /*!

--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -203,6 +203,13 @@ void AlertConditionsController::setProperties(const QVariantMap& properties)
   addStoredConditions();
 }
 
+void AlertConditionsController::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == AlertConstants::ALERT_CONDITIONS_PROPERTYNAME ||
+      propertyName == MessageFeedConstants::MESSAGE_FEEDS_PROPERTYNAME)
+    setProperties(properties);
+}
+
 /*!
   \brief Sets the active state of this tool to \a active.
 

--- a/Shared/alerts/AlertConditionsController.h
+++ b/Shared/alerts/AlertConditionsController.h
@@ -70,8 +70,8 @@ public:
 
   // AbstractTool interface
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   void setActive(bool active) override;
 

--- a/Shared/alerts/AlertConditionsController.h
+++ b/Shared/alerts/AlertConditionsController.h
@@ -71,6 +71,7 @@ public:
   // AbstractTool interface
   QString toolName() const override;
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   void setActive(bool active) override;
 

--- a/Shared/markup/MarkupBroadcast.cpp
+++ b/Shared/markup/MarkupBroadcast.cpp
@@ -113,7 +113,7 @@ QString MarkupBroadcast::toolName() const
 /*!
  \brief Sets \a properties from the configuration file
  */
-void MarkupBroadcast::setProperties(const QVariantMap& properties)
+void MarkupBroadcast::toolInitProperties(const QVariantMap& properties)
 {
   m_username = properties[USERNAME_PROPERTYNAME].toString();
 
@@ -132,13 +132,12 @@ void MarkupBroadcast::setProperties(const QVariantMap& properties)
   updateDataListener();
 }
 
-void MarkupBroadcast::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool MarkupBroadcast::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == USERNAME_PROPERTYNAME ||
-      propertyName == ROOTDATA_PROPERTYNAME ||
-      propertyName == MARKUPCONFIG_PROPERTYNAME ||
-      propertyName == UDPPORT_PROPERTYNAME)
-    setProperties(properties);
+  return (propertyName == USERNAME_PROPERTYNAME ||
+          propertyName == ROOTDATA_PROPERTYNAME ||
+          propertyName == MARKUPCONFIG_PROPERTYNAME ||
+          propertyName == UDPPORT_PROPERTYNAME);
 }
 
 /*!

--- a/Shared/markup/MarkupBroadcast.cpp
+++ b/Shared/markup/MarkupBroadcast.cpp
@@ -134,10 +134,16 @@ void MarkupBroadcast::toolInitProperties(const QVariantMap& properties)
 
 bool MarkupBroadcast::shouldSetProperties(const QString& propertyName)
 {
-  return (propertyName == USERNAME_PROPERTYNAME ||
-          propertyName == ROOTDATA_PROPERTYNAME ||
-          propertyName == MARKUPCONFIG_PROPERTYNAME ||
-          propertyName == UDPPORT_PROPERTYNAME);
+  // list all property names that should cause the tool to re-initialize
+  static const std::unordered_set<QString> propertyNames
+  {
+    USERNAME_PROPERTYNAME,
+    ROOTDATA_PROPERTYNAME,
+    MARKUPCONFIG_PROPERTYNAME,
+    UDPPORT_PROPERTYNAME
+  };
+
+  return setContainsString(propertyNames, propertyName);
 }
 
 /*!

--- a/Shared/markup/MarkupBroadcast.cpp
+++ b/Shared/markup/MarkupBroadcast.cpp
@@ -132,6 +132,15 @@ void MarkupBroadcast::setProperties(const QVariantMap& properties)
   updateDataListener();
 }
 
+void MarkupBroadcast::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == USERNAME_PROPERTYNAME ||
+      propertyName == ROOTDATA_PROPERTYNAME ||
+      propertyName == MARKUPCONFIG_PROPERTYNAME ||
+      propertyName == UDPPORT_PROPERTYNAME)
+    setProperties(properties);
+}
+
 /*!
    \brief Broadcasts the markup JSON (\a json) over a UDP port.
  */

--- a/Shared/markup/MarkupBroadcast.h
+++ b/Shared/markup/MarkupBroadcast.h
@@ -39,6 +39,7 @@ public:
 
   QString toolName() const override;
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   void broadcastMarkup(const QString& json);
 

--- a/Shared/markup/MarkupBroadcast.h
+++ b/Shared/markup/MarkupBroadcast.h
@@ -38,8 +38,8 @@ public:
   ~MarkupBroadcast();
 
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   void broadcastMarkup(const QString& json);
 

--- a/Shared/markup/MarkupController.cpp
+++ b/Shared/markup/MarkupController.cpp
@@ -100,6 +100,12 @@ void MarkupController::setProperties(const QVariantMap& properties)
   m_username = properties.value(USERNAME_PROPERTYNAME).toString();
 }
 
+void MarkupController::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == USERNAME_PROPERTYNAME)
+    setProperties(properties);
+}
+
 /*!
  \brief Sets the tool to be \a active.
  */

--- a/Shared/markup/MarkupController.cpp
+++ b/Shared/markup/MarkupController.cpp
@@ -95,15 +95,14 @@ MarkupController::~MarkupController()
 /*!
  \brief Sets \a properties from the configuration file
  */
-void MarkupController::setProperties(const QVariantMap& properties)
+void MarkupController::toolInitProperties(const QVariantMap& properties)
 {
   m_username = properties.value(USERNAME_PROPERTYNAME).toString();
 }
 
-void MarkupController::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool MarkupController::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == USERNAME_PROPERTYNAME)
-    setProperties(properties);
+  return (propertyName == USERNAME_PROPERTYNAME);
 }
 
 /*!

--- a/Shared/markup/MarkupController.h
+++ b/Shared/markup/MarkupController.h
@@ -44,8 +44,8 @@ public:
   explicit MarkupController(QObject* parent = nullptr);
   ~MarkupController();
 
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   Q_INVOKABLE void setColor(const QColor& color);
   Q_INVOKABLE void setWidth(float width);

--- a/Shared/markup/MarkupController.h
+++ b/Shared/markup/MarkupController.h
@@ -45,6 +45,7 @@ public:
   ~MarkupController();
 
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   Q_INVOKABLE void setColor(const QColor& color);
   Q_INVOKABLE void setWidth(float width);

--- a/Shared/messages/MessageFeedsController.cpp
+++ b/Shared/messages/MessageFeedsController.cpp
@@ -267,6 +267,16 @@ void MessageFeedsController::setProperties(const QVariantMap& properties)
   }
 }
 
+void MessageFeedsController::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == RESOURCE_DIRECTORY_PROPERTYNAME ||
+      propertyName == MessageFeedConstants::MESSAGE_FEEDS_PROPERTYNAME ||
+      propertyName == AppConstants::USERNAME_PROPERTYNAME ||
+      propertyName == MessageFeedConstants::MESSAGE_FEED_UDP_PORTS_PROPERTYNAME ||
+      propertyName == MessageFeedConstants::LOCATION_BROADCAST_CONFIG_PROPERTYNAME)
+    setProperties(properties);
+}
+
 /*!
   \brief Sets the data path to be used for symbol style resources as \a resourcePath.
  */

--- a/Shared/messages/MessageFeedsController.cpp
+++ b/Shared/messages/MessageFeedsController.cpp
@@ -231,7 +231,7 @@ void MessageFeedsController::setupFeeds()
     \li \c UserName - the name of the user to be broadcast.
   \endlist
  */
-void MessageFeedsController::setProperties(const QVariantMap& properties)
+void MessageFeedsController::toolInitProperties(const QVariantMap& properties)
 {
   setResourcePath(properties[RESOURCE_DIRECTORY_PROPERTYNAME].toString());
   m_messageFeedProperties = properties[MessageFeedConstants::MESSAGE_FEEDS_PROPERTYNAME].toList();
@@ -267,14 +267,13 @@ void MessageFeedsController::setProperties(const QVariantMap& properties)
   }
 }
 
-void MessageFeedsController::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool MessageFeedsController::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == RESOURCE_DIRECTORY_PROPERTYNAME ||
-      propertyName == MessageFeedConstants::MESSAGE_FEEDS_PROPERTYNAME ||
-      propertyName == AppConstants::USERNAME_PROPERTYNAME ||
-      propertyName == MessageFeedConstants::MESSAGE_FEED_UDP_PORTS_PROPERTYNAME ||
-      propertyName == MessageFeedConstants::LOCATION_BROADCAST_CONFIG_PROPERTYNAME)
-    setProperties(properties);
+  return (propertyName == RESOURCE_DIRECTORY_PROPERTYNAME ||
+          propertyName == MessageFeedConstants::MESSAGE_FEEDS_PROPERTYNAME ||
+          propertyName == AppConstants::USERNAME_PROPERTYNAME ||
+          propertyName == MessageFeedConstants::MESSAGE_FEED_UDP_PORTS_PROPERTYNAME ||
+          propertyName == MessageFeedConstants::LOCATION_BROADCAST_CONFIG_PROPERTYNAME);
 }
 
 /*!

--- a/Shared/messages/MessageFeedsController.cpp
+++ b/Shared/messages/MessageFeedsController.cpp
@@ -269,11 +269,17 @@ void MessageFeedsController::toolInitProperties(const QVariantMap& properties)
 
 bool MessageFeedsController::shouldSetProperties(const QString& propertyName)
 {
-  return (propertyName == RESOURCE_DIRECTORY_PROPERTYNAME ||
-          propertyName == MessageFeedConstants::MESSAGE_FEEDS_PROPERTYNAME ||
-          propertyName == AppConstants::USERNAME_PROPERTYNAME ||
-          propertyName == MessageFeedConstants::MESSAGE_FEED_UDP_PORTS_PROPERTYNAME ||
-          propertyName == MessageFeedConstants::LOCATION_BROADCAST_CONFIG_PROPERTYNAME);
+  // list all property names that should cause the tool to re-initialize
+  static const std::unordered_set<QString> propertyNames
+  {
+    RESOURCE_DIRECTORY_PROPERTYNAME,
+    MessageFeedConstants::MESSAGE_FEEDS_PROPERTYNAME,
+    AppConstants::USERNAME_PROPERTYNAME,
+    MessageFeedConstants::MESSAGE_FEED_UDP_PORTS_PROPERTYNAME,
+    MessageFeedConstants::LOCATION_BROADCAST_CONFIG_PROPERTYNAME
+  };
+
+  return setContainsString(propertyNames, propertyName);
 }
 
 /*!

--- a/Shared/messages/MessageFeedsController.h
+++ b/Shared/messages/MessageFeedsController.h
@@ -64,6 +64,7 @@ public:
 
   QString toolName() const override;
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   QString resourcePath() const { return m_resourcePath; }
   void setResourcePath(const QString& resourcePath);

--- a/Shared/messages/MessageFeedsController.h
+++ b/Shared/messages/MessageFeedsController.h
@@ -63,8 +63,8 @@ public:
   void removeDataListener(DataListener* dataListener);
 
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   QString resourcePath() const { return m_resourcePath; }
   void setResourcePath(const QString& resourcePath);

--- a/Shared/messages/ObservationReportController.cpp
+++ b/Shared/messages/ObservationReportController.cpp
@@ -118,6 +118,13 @@ void ObservationReportController::setProperties(const QVariantMap& properties)
   }
 }
 
+void ObservationReportController::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == AppConstants::USERNAME_PROPERTYNAME ||
+      propertyName == MessageFeedConstants::OBSERVATION_REPORT_CONFIG_PROPERTYNAME)
+    setProperties(properties);
+}
+
 /*!
   \property ObservationReportController::observedBy
   \brief Returns the name of the unit making the observation report.

--- a/Shared/messages/ObservationReportController.cpp
+++ b/Shared/messages/ObservationReportController.cpp
@@ -101,7 +101,7 @@ QString ObservationReportController::toolName() const
  *  \li \c UserName. The user name (observed by) for observation reports.
  * \endlist
  */
-void ObservationReportController::setProperties(const QVariantMap& properties)
+void ObservationReportController::toolInitProperties(const QVariantMap& properties)
 {
   auto findUserNameIt = properties.find(AppConstants::USERNAME_PROPERTYNAME);
   if (findUserNameIt != properties.end())
@@ -118,11 +118,10 @@ void ObservationReportController::setProperties(const QVariantMap& properties)
   }
 }
 
-void ObservationReportController::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool ObservationReportController::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == AppConstants::USERNAME_PROPERTYNAME ||
-      propertyName == MessageFeedConstants::OBSERVATION_REPORT_CONFIG_PROPERTYNAME)
-    setProperties(properties);
+  return (propertyName == AppConstants::USERNAME_PROPERTYNAME ||
+          propertyName == MessageFeedConstants::OBSERVATION_REPORT_CONFIG_PROPERTYNAME);
 }
 
 /*!

--- a/Shared/messages/ObservationReportController.h
+++ b/Shared/messages/ObservationReportController.h
@@ -51,8 +51,8 @@ public:
 
   QString toolName() const override;
 
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   QString observedBy() const;
   void setObservedBy(const QString& observedBy);

--- a/Shared/messages/ObservationReportController.h
+++ b/Shared/messages/ObservationReportController.h
@@ -52,6 +52,7 @@ public:
   QString toolName() const override;
 
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   QString observedBy() const;
   void setObservedBy(const QString& observedBy);

--- a/Shared/packages/OpenMobileScenePackageController.cpp
+++ b/Shared/packages/OpenMobileScenePackageController.cpp
@@ -94,7 +94,7 @@ QString OpenMobileScenePackageController::toolName() const
  *  \li SceneIndex. The index of the scene in the current package.
  * \endlist
  */
-void OpenMobileScenePackageController::setProperties(const QVariantMap& properties)
+void OpenMobileScenePackageController::toolInitProperties(const QVariantMap& properties)
 {
   const QString newPackageDirectoryPath = properties.value(PACKAGE_DIRECTORY_PROPERTYNAME).toString();
   const bool dataPathChanged = setPackageDataPath(newPackageDirectoryPath);
@@ -118,12 +118,11 @@ void OpenMobileScenePackageController::setProperties(const QVariantMap& properti
   }
 }
 
-void OpenMobileScenePackageController::setProperty(const QString& propertyName, const QVariantMap& properties)
+bool OpenMobileScenePackageController::shouldSetProperties(const QString& propertyName)
 {
-  if (propertyName == PACKAGE_DIRECTORY_PROPERTYNAME ||
-      propertyName == CURRENT_PACKAGE_PROPERTYNAME ||
-      propertyName == SCENE_INDEX_PROPERTYNAME)
-    setProperties(properties);
+  return (propertyName == PACKAGE_DIRECTORY_PROPERTYNAME ||
+          propertyName == CURRENT_PACKAGE_PROPERTYNAME ||
+          propertyName == SCENE_INDEX_PROPERTYNAME);
 }
 
 /*!

--- a/Shared/packages/OpenMobileScenePackageController.cpp
+++ b/Shared/packages/OpenMobileScenePackageController.cpp
@@ -120,9 +120,15 @@ void OpenMobileScenePackageController::toolInitProperties(const QVariantMap& pro
 
 bool OpenMobileScenePackageController::shouldSetProperties(const QString& propertyName)
 {
-  return (propertyName == PACKAGE_DIRECTORY_PROPERTYNAME ||
-          propertyName == CURRENT_PACKAGE_PROPERTYNAME ||
-          propertyName == SCENE_INDEX_PROPERTYNAME);
+  // list all property names that should cause the tool to re-initialize
+  static const std::unordered_set<QString> propertyNames
+  {
+    PACKAGE_DIRECTORY_PROPERTYNAME,
+    CURRENT_PACKAGE_PROPERTYNAME,
+    SCENE_INDEX_PROPERTYNAME
+  };
+
+  return setContainsString(propertyNames, propertyName);
 }
 
 /*!

--- a/Shared/packages/OpenMobileScenePackageController.cpp
+++ b/Shared/packages/OpenMobileScenePackageController.cpp
@@ -118,6 +118,14 @@ void OpenMobileScenePackageController::setProperties(const QVariantMap& properti
   }
 }
 
+void OpenMobileScenePackageController::setProperty(const QString& propertyName, const QVariantMap& properties)
+{
+  if (propertyName == PACKAGE_DIRECTORY_PROPERTYNAME ||
+      propertyName == CURRENT_PACKAGE_PROPERTYNAME ||
+      propertyName == SCENE_INDEX_PROPERTYNAME)
+    setProperties(properties);
+}
+
 /*!
   \internal
 

--- a/Shared/packages/OpenMobileScenePackageController.h
+++ b/Shared/packages/OpenMobileScenePackageController.h
@@ -55,8 +55,8 @@ public:
   ~OpenMobileScenePackageController() override;
 
   QString toolName() const override;
-  void setProperties(const QVariantMap& properties) override;
-  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
+  void toolInitProperties(const QVariantMap& properties) override;
+  bool shouldSetProperties(const QString& propertyName) override;
 
   Q_INVOKABLE void selectPackageName(const QString& newPackageName);
   Q_INVOKABLE void selectScene(int newSceneIndex);

--- a/Shared/packages/OpenMobileScenePackageController.h
+++ b/Shared/packages/OpenMobileScenePackageController.h
@@ -56,6 +56,7 @@ public:
 
   QString toolName() const override;
   void setProperties(const QVariantMap& properties) override;
+  void setProperty(const QString& propertyName, const QVariantMap& properties) override;
 
   Q_INVOKABLE void selectPackageName(const QString& newPackageName);
   Q_INVOKABLE void selectScene(int newSceneIndex);


### PR DESCRIPTION
- Add setProperty to AbstractTool
- Modify DsaController to call setProperty in onPropertyChanged signal
- Update tool controllers to implement setProperty and subsequently call their existing setProperties method if a relevant property was altered

@JamesMBallard 