### PR TITLE
Read from the config file each call to 'home'

### DIFF
--- a/Handheld/Handheld.cpp
+++ b/Handheld/Handheld.cpp
@@ -26,7 +26,6 @@
 
 // DSA headers
 #include "DsaController.h"
-#include "ToolManager.h"
 #include "ToolResourceProvider.h"
 
 using namespace Esri::ArcGISRuntime;
@@ -36,63 +35,44 @@ namespace Handheld {
 
 Handheld::Handheld(QQuickItem* parent /* = nullptr */):
   QQuickItem(parent),
-  m_controller(new DsaController(this))
+  m_controller(DsaController::instance())
 {
 }
 
-/*!
-   \brief Destructor
- */
 Handheld::~Handheld()
 {
 }
 
-
-/*!
-   \brief Apply scene to the SceneView.
- */
 void Handheld::componentComplete()
 {
   QQuickItem::componentComplete();
 
   // find QML SceneView component
   m_sceneView = findChild<SceneQuickView*>("sceneView");
-  connect(m_sceneView, &SceneQuickView::errorOccurred, m_controller, &DsaController::onError);
+  connect(m_sceneView, &SceneQuickView::errorOccurred, &m_controller, &DsaController::onError);
 
   // connect to the DSA controller errors
-  connect(m_controller, &DsaController::errorOccurred, this, [this]
-          (const QString& message, const QString& additionalMessage)
+  connect(&m_controller, &DsaController::errorOccurred, this, [this](const QString& message, const QString& additionalMessage)
   {
     emit errorOccurred(message, additionalMessage);
   });
 
-  connect(ToolResourceProvider::instance(), &ToolResourceProvider::sceneChanged, this, [this]()
+  auto* trp = ToolResourceProvider::instance();
+  connect(trp, &ToolResourceProvider::sceneChanged, this, [this, trp]()
   {
-    m_sceneView->setArcGISScene(m_controller->scene());
+    m_sceneView->setArcGISScene(trp->scene());
   });
 
-  m_controller->init(m_sceneView);
+  m_controller.init(m_sceneView);
 
   // setup the connections from the view to the resource provider
-  connect(m_sceneView, &SceneQuickView::spatialReferenceChanged,
-          ToolResourceProvider::instance(), &ToolResourceProvider::spatialReferenceChanged);
-
-  connect(m_sceneView, &SceneQuickView::mouseClicked,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onMouseClicked);
-
-  connect(m_sceneView, &SceneQuickView::mousePressed,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onMousePressed);
-
-  connect(m_sceneView, &SceneQuickView::mouseMoved,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onMouseMoved);
-
-  connect(m_sceneView, &SceneQuickView::mouseReleased,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onMouseReleased);
-
-  connect(m_sceneView, &SceneQuickView::mousePressedAndHeld,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onMousePressedAndHeld);
-
-  connect(ToolResourceProvider::instance(), &ToolResourceProvider::setMouseCursorRequested, this, [this](const QCursor& mouseCursor)
+  connect(m_sceneView, &SceneQuickView::spatialReferenceChanged, trp, &ToolResourceProvider::spatialReferenceChanged);
+  connect(m_sceneView, &SceneQuickView::mouseClicked,            trp, &ToolResourceProvider::onMouseClicked);
+  connect(m_sceneView, &SceneQuickView::mousePressed,            trp, &ToolResourceProvider::onMousePressed);
+  connect(m_sceneView, &SceneQuickView::mousePressedAndHeld,     trp, &ToolResourceProvider::onMousePressedAndHeld);
+  connect(m_sceneView, &SceneQuickView::mouseMoved,              trp, &ToolResourceProvider::onMouseMoved);
+  connect(m_sceneView, &SceneQuickView::mouseReleased,           trp, &ToolResourceProvider::onMouseReleased);
+  connect(trp, &ToolResourceProvider::setMouseCursorRequested, this, [this](const QCursor& mouseCursor)
   {
     m_sceneView->setCursor(mouseCursor);
   });
@@ -100,7 +80,7 @@ void Handheld::componentComplete()
 
 void Handheld::resetToDefaultScene()
 {
-  m_controller->resetToDefaultScene();
+  DsaController::instance().resetToDefaultScene();
 }
 
 } // Handheld

--- a/Handheld/Handheld.h
+++ b/Handheld/Handheld.h
@@ -45,8 +45,8 @@ signals:
   void errorOccurred(const QString& message, const QString& additionalMessage);
 
 private:
-  Esri::ArcGISRuntime::SceneQuickView*    m_sceneView = nullptr;
-  DsaController*                          m_controller = nullptr;
+  Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
+  DsaController& m_controller;
 };
 
 } // Handheld

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -145,6 +145,7 @@ Scene* DsaController::scene() const
 void DsaController::init(GeoView* geoView)
 {
   ToolResourceProvider::instance()->setGeoView(geoView);
+  ToolManager::instance().setDsaController(this);
 
   bool hasActiveScene = false;
   auto openScenePackageTool = ToolManager::instance().tool<OpenMobileScenePackageController>();
@@ -555,7 +556,7 @@ void DsaController::writeInitialLocation(const Viewpoint& viewpoint)
   m_dsaSettings[AppConstants::INITIALLOCATION_PROPERTYNAME] = initialLocationJson.toVariantMap();
 }
 
-Viewpoint DsaController::readInitialLocation()
+Viewpoint DsaController::readInitialLocation() const
 {
   return viewpointFromJson(m_dsaSettings[AppConstants::INITIALLOCATION_PROPERTYNAME].toJsonObject());
 }

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -88,8 +88,7 @@ QJsonObject defaultViewpoint();
 /*!
   \brief Constructor for a model taking an optional \a parent.
  */
-DsaController::DsaController(QObject* parent):
-  QObject(parent),
+DsaController::DsaController():
   m_scene(new Scene(this)),
   m_jsonFormat(QSettings::registerFormat("json", &readJsonFile, &writeJsonFile)),
   m_conflictingToolNames{QStringLiteral("Alert Conditions"),
@@ -129,6 +128,13 @@ DsaController::~DsaController()
   saveSettings();
 }
 
+DsaController& DsaController::instance()
+{
+  static DsaController instance{};
+
+  return instance;
+}
+
 /*!
   \brief Returns the Esri::ArcGISRuntime::Scene used by the app.
  */
@@ -145,7 +151,6 @@ Scene* DsaController::scene() const
 void DsaController::init(GeoView* geoView)
 {
   ToolResourceProvider::instance()->setGeoView(geoView);
-  ToolManager::instance().setDsaController(this);
 
   bool hasActiveScene = false;
   auto openScenePackageTool = ToolManager::instance().tool<OpenMobileScenePackageController>();

--- a/Shared/DsaController.h
+++ b/Shared/DsaController.h
@@ -49,6 +49,7 @@ public:
   void init(Esri::ArcGISRuntime::GeoView* geoView);
 
   void resetToDefaultScene();
+  Esri::ArcGISRuntime::Viewpoint readInitialLocation() const;
 
 public slots:
   void onError(const Esri::ArcGISRuntime::Error& error);
@@ -71,7 +72,6 @@ private:
   void updateInitialLocationOnSceneChange(bool isInitialization);
 
   void writeInitialLocation(const Esri::ArcGISRuntime::Viewpoint& viewpoint);
-  Esri::ArcGISRuntime::Viewpoint readInitialLocation();
 
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   LayerCacheManager* m_cacheManager = nullptr;

--- a/Shared/DsaController.h
+++ b/Shared/DsaController.h
@@ -41,8 +41,9 @@ class DsaController : public QObject
   Q_OBJECT
 
 public:
-  DsaController(QObject* parent = nullptr);
   ~DsaController();
+
+  static DsaController& instance();
 
   Esri::ArcGISRuntime::Scene* scene() const;
 
@@ -62,6 +63,7 @@ signals:
   void errorOccurred(const QString& message, const QString& additionalMessage);
 
 private:
+  DsaController();
   void setupConfig();
   void createDefaultSettings();
   void saveSettings();

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -118,13 +118,10 @@ void NavigationController::zoomToInitialLocation()
     return;
 
   // read the users defined viewpoint from the config file
-  if (const auto* dsaController = ToolManager::instance().dsaController(); dsaController)
+  if (const auto initialViewpoint = DsaController::instance().readInitialLocation(); !initialViewpoint.isEmpty())
   {
-    if (const auto initialViewpoint = dsaController->readInitialLocation(); !initialViewpoint.isEmpty())
-    {
-      m_sceneView->setViewpointAsync(initialViewpoint, 1.0f);
-      return;
-    }
+    m_sceneView->setViewpointAsync(initialViewpoint, 1.0f);
+    return;
   }
 
   // default to the scene view object initial viewpoint

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -37,6 +37,7 @@
 #include <QScreen>
 
 // DSA headers
+#include "DsaController.h"
 #include "DsaUtility.h"
 #include "ToolManager.h"
 #include "ToolResourceProvider.h"
@@ -116,6 +117,17 @@ void NavigationController::zoomToInitialLocation()
   if (!m_is3d)
     return;
 
+  // read the users defined viewpoint from the config file
+  if (const auto* dsaController = ToolManager::instance().dsaController(); dsaController)
+  {
+    if (const auto initialViewpoint = dsaController->readInitialLocation(); !initialViewpoint.isEmpty())
+    {
+      m_sceneView->setViewpointAsync(initialViewpoint, 1.0f);
+      return;
+    }
+  }
+
+  // default to the scene view object initial viewpoint
   m_sceneView->setViewpointAsync(m_sceneView->arcGISScene()->initialViewpoint(), 1.0f);
 }
 

--- a/Shared/ToolManager.cpp
+++ b/Shared/ToolManager.cpp
@@ -27,7 +27,7 @@ namespace Dsa
  */
 ToolManager& ToolManager::instance()
 {
-  static ToolManager instance;
+  static ToolManager instance{};
 
   return instance;
 }
@@ -108,16 +108,6 @@ void ToolManager::clearTools()
 AbstractTool* ToolManager::tool(const QString& toolName) const
 {
   return m_tools[toolName];
-}
-
-void ToolManager::setDsaController(const DsaController* dsaController)
-{
-  m_dsaController = dsaController;
-}
-
-const DsaController* ToolManager::dsaController() const
-{
-  return m_dsaController;
 }
 
 /*! \brief Returns a begin iterator to the list of tools.

--- a/Shared/ToolManager.cpp
+++ b/Shared/ToolManager.cpp
@@ -110,6 +110,16 @@ AbstractTool* ToolManager::tool(const QString& toolName) const
   return m_tools[toolName];
 }
 
+void ToolManager::setDsaController(const DsaController* dsaController)
+{
+  m_dsaController = dsaController;
+}
+
+const DsaController* ToolManager::dsaController() const
+{
+  return m_dsaController;
+}
+
 /*! \brief Returns a begin iterator to the list of tools.
  *
  */

--- a/Shared/ToolManager.h
+++ b/Shared/ToolManager.h
@@ -49,9 +49,6 @@ public:
 
   AbstractTool* tool(const QString& toolName) const;
 
-  void setDsaController(const DsaController* dsaController);
-  const DsaController* dsaController() const;
-
   template<class T>
   T* tool() const;
 
@@ -69,7 +66,6 @@ private:
   ToolManager();
 
   ToolsList m_tools;
-  const DsaController* m_dsaController = nullptr;
 };
 
 template<class T>

--- a/Shared/ToolManager.h
+++ b/Shared/ToolManager.h
@@ -25,6 +25,7 @@ namespace Dsa
 {
 
 class AbstractTool;
+class DsaController;
 
 class ToolManager : public QObject
 {
@@ -48,6 +49,9 @@ public:
 
   AbstractTool* tool(const QString& toolName) const;
 
+  void setDsaController(const DsaController* dsaController);
+  const DsaController* dsaController() const;
+
   template<class T>
   T* tool() const;
 
@@ -65,6 +69,7 @@ private:
   ToolManager();
 
   ToolsList m_tools;
+  const DsaController* m_dsaController;
 };
 
 template<class T>

--- a/Shared/ToolManager.h
+++ b/Shared/ToolManager.h
@@ -69,7 +69,7 @@ private:
   ToolManager();
 
   ToolsList m_tools;
-  const DsaController* m_dsaController;
+  const DsaController* m_dsaController = nullptr;
 };
 
 template<class T>

--- a/Shared/ToolResourceProvider.cpp
+++ b/Shared/ToolResourceProvider.cpp
@@ -34,14 +34,13 @@ namespace Dsa
 ToolResourceProvider::ToolResourceProvider(QObject* parent /*= nullptr*/):
   QObject(parent)
 {
-
 }
 
 ToolResourceProvider* ToolResourceProvider::instance()
 {
-  static ToolResourceProvider s_instance;
+  static ToolResourceProvider instance{};
 
-  return &s_instance;
+  return &instance;
 }
 
 ToolResourceProvider::~ToolResourceProvider()

--- a/Vehicle/Vehicle.cpp
+++ b/Vehicle/Vehicle.cpp
@@ -35,7 +35,7 @@ namespace Vehicle {
 
 Vehicle::Vehicle(QQuickItem* parent /* = nullptr */):
   QQuickItem(parent),
-  m_controller(new DsaController(this))
+  m_controller(DsaController::instance())
 {
 }
 
@@ -49,45 +49,34 @@ void Vehicle::componentComplete()
 
   // find QML SceneView component
   m_sceneView = findChild<SceneQuickView*>("sceneView");
-  connect(m_sceneView, &SceneQuickView::errorOccurred, m_controller, &DsaController::onError);
+  connect(m_sceneView, &SceneQuickView::errorOccurred, &m_controller, &DsaController::onError);
 
   // connect to the DSA controller errors
-  connect(m_controller, &DsaController::errorOccurred, this, [this]
-          (const QString& message, const QString& additionalMessage)
+  connect(&m_controller, &DsaController::errorOccurred, this, [this](const QString& message, const QString& additionalMessage)
   {
     emit errorOccurred(message, additionalMessage);
   });
 
-  connect(ToolResourceProvider::instance(), &ToolResourceProvider::sceneChanged, this, [this]()
+  auto* trp = ToolResourceProvider::instance();
+  connect(trp, &ToolResourceProvider::sceneChanged, this, [this, trp]()
   {
-    m_sceneView->setArcGISScene(ToolResourceProvider::instance()->scene());
+    m_sceneView->setArcGISScene(trp->scene());
   });
 
-  m_controller->init(m_sceneView);
+  m_controller.init(m_sceneView);
 
   // setup the connections from the view to the resource provider
-  connect(m_sceneView, &SceneQuickView::spatialReferenceChanged,
-          ToolResourceProvider::instance(), &ToolResourceProvider::spatialReferenceChanged);
-
-  connect(m_sceneView, &SceneQuickView::mouseClicked,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onMouseClicked);
-
-  connect(m_sceneView, &SceneQuickView::mousePressed,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onMousePressed);
-
-  connect(m_sceneView, &SceneQuickView::mousePressedAndHeld,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onMousePressedAndHeld);
-
-  connect(m_sceneView, &SceneQuickView::mouseMoved,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onMouseMoved);
-
-  connect(m_sceneView, &SceneQuickView::mouseReleased,
-          ToolResourceProvider::instance(), &ToolResourceProvider::onMouseReleased);
+  connect(m_sceneView, &SceneQuickView::spatialReferenceChanged, trp, &ToolResourceProvider::spatialReferenceChanged);
+  connect(m_sceneView, &SceneQuickView::mouseClicked,            trp, &ToolResourceProvider::onMouseClicked);
+  connect(m_sceneView, &SceneQuickView::mousePressed,            trp, &ToolResourceProvider::onMousePressed);
+  connect(m_sceneView, &SceneQuickView::mousePressedAndHeld,     trp, &ToolResourceProvider::onMousePressedAndHeld);
+  connect(m_sceneView, &SceneQuickView::mouseMoved,              trp, &ToolResourceProvider::onMouseMoved);
+  connect(m_sceneView, &SceneQuickView::mouseReleased,           trp, &ToolResourceProvider::onMouseReleased);
 }
 
 void Vehicle::resetToDefaultScene()
 {
-  m_controller->resetToDefaultScene();
+  DsaController::instance().resetToDefaultScene();
 }
 
 } // Vehicle

--- a/Vehicle/Vehicle.h
+++ b/Vehicle/Vehicle.h
@@ -45,9 +45,8 @@ signals:
   void errorOccurred(const QString& message, const QString& additionalMessage);
 
 private:
-
-  Esri::ArcGISRuntime::SceneQuickView*    m_sceneView = nullptr;
-  DsaController*                          m_controller = nullptr;
+  Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
+  DsaController& m_controller;
 };
 
 } // Vehicle


### PR DESCRIPTION
add a reference to the DsaController object on the ToolManager.
make the readInitialLocation method public but marked as const
use the result of the function for home instead of initialViewpoint on the scene which might not match what users have configured based on the startup sequence and packages loaded.

#458 