### PR TITLE
Dtedder/445 use relative paths in config

### DIFF
--- a/Shared/AddLocalDataController.cpp
+++ b/Shared/AddLocalDataController.cpp
@@ -99,9 +99,6 @@ AddLocalDataController::AddLocalDataController(QObject* parent /* = nullptr */):
   AbstractTool(parent),
   m_localDataModel(new DataItemListModel(this))
 {
-  // add the base path to the string list
-  addPathToDirectoryList(".");
-
   // create file filter list
   m_fileFilterList = QStringList{allData(), rasterData(), geodatabaseData(),
       sceneLayerData(), tilePackageData(), shapefileData(), geopackageData(),

--- a/Shared/AddLocalDataController.cpp
+++ b/Shared/AddLocalDataController.cpp
@@ -100,7 +100,7 @@ AddLocalDataController::AddLocalDataController(QObject* parent /* = nullptr */):
   m_localDataModel(new DataItemListModel(this))
 {
   // add the base path to the string list
-  addPathToDirectoryList(DsaUtility::activeConfigurationPath());
+  addPathToDirectoryList(".");
 
   // create file filter list
   m_fileFilterList = QStringList{allData(), rasterData(), geodatabaseData(),
@@ -147,21 +147,21 @@ void AddLocalDataController::addPathToDirectoryList(const QString& path)
  */
 void AddLocalDataController::refreshLocalDataModel(const QString& fileType)
 {
-  QStringList fileFilters = determineFileFilters(fileType);
+  const auto fileFilters = determineFileFilters(fileType);
   m_localDataModel->clear();
 
-  for (const QString& path : m_dataPaths)
+  for (const auto& path : std::as_const(m_dataPaths))
   {
-    QDir localDir(path);
+    QDir localDir{path};
 
     if (fileFilters.length() > 0)
       localDir.setNameFilters(fileFilters);
 
-    for (const QString& file : localDir.entryList(QDir::Files, QDir::Name))
+    const auto localFiles = localDir.entryList(QDir::Files, QDir::Name);
+    std::for_each(std::cbegin(localFiles), std::cend(localFiles), [&](const auto& localFile)
     {
-      QFileInfo fileInfo(localDir, file);
-      m_localDataModel->addDataItem(fileInfo.absoluteFilePath());
-    }
+      m_localDataModel->addDataItem(localDir.filePath(localFile));
+    });
   }
 }
 

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -98,6 +98,10 @@ DsaController::DsaController(QObject* parent):
                          QStringLiteral("viewshed"),
                          QStringLiteral("Observation Report")}
 {
+  // set the current path for the application to the active configuration directory
+  // so we can use relative paths for data in the configuration file
+  QDir::setCurrent(DsaUtility::activeConfigurationPath());
+
   // setup config settings
   setupConfig();
   m_scene->setInitialViewpoint(viewpointFromJson(defaultViewpoint()));
@@ -378,18 +382,6 @@ void DsaController::setupConfig()
 
 /*! \brief internal
  *
- * Writes the default local data paths as JSON to the settings map.
- */
-void DsaController::writeDefaultLocalDataPaths()
-{
-  const QString rootDir = m_dsaSettings[AppConstants::PROPERTYNAME_ROOT_DATA_DIRECTORY].toString();
-  QStringList pathsList{QString("%1/").arg(rootDir),
-        QString("%1/OperationalData").arg(rootDir)};
-  m_dsaSettings[QStringLiteral("LocalDataPaths")] = pathsList;
-}
-
-/*! \brief internal
- *
  * Writes the default Alert Conditions as JSON to the settings map.
  */
 void DsaController::writeDefaultConditions()
@@ -507,13 +499,13 @@ bool DsaController::isConflictingTool(const QString& toolName) const
 void DsaController::createDefaultSettings()
 {
   // setup the defaults
-  m_dsaSettings[AppConstants::PROPERTYNAME_ROOT_DATA_DIRECTORY] = DsaUtility::activeConfigurationPath();
+  m_dsaSettings[AppConstants::PROPERTYNAME_ROOT_DATA_DIRECTORY] = DsaUtility::FILE_PATH_CURRENT_DIRECTORY;
   m_dsaSettings[AppConstants::PROPERTYNAME_USERNAME] = QHostInfo::localHostName();
-  m_dsaSettings[AppConstants::PROPERTYNAME_BASEMAP_DIRECTORY] = QString("%1/BasemapData").arg(m_dsaSettings[AppConstants::PROPERTYNAME_ROOT_DATA_DIRECTORY].toString());
-  m_dsaSettings[AppConstants::PROPERTYNAME_ELEVATION_DIRECTORY] = QString("%1/ElevationData").arg(m_dsaSettings[AppConstants::PROPERTYNAME_ROOT_DATA_DIRECTORY].toString());
-  m_dsaSettings[AppConstants::PROPERTYNAME_SIMULATION_DIRECTORY] = QString("%1/SimulationData").arg(m_dsaSettings[AppConstants::PROPERTYNAME_ROOT_DATA_DIRECTORY].toString());
-  m_dsaSettings[LocationController::PROPERTY_NAME_RESOURCE_DIRECTORY] = QString("%1/ResourceData").arg(m_dsaSettings[AppConstants::PROPERTYNAME_ROOT_DATA_DIRECTORY].toString());
-  writeDefaultLocalDataPaths();
+  m_dsaSettings[AppConstants::PROPERTYNAME_BASEMAP_DIRECTORY] = QStringLiteral("./BasemapData");
+  m_dsaSettings[AppConstants::PROPERTYNAME_ELEVATION_DIRECTORY] = QStringLiteral("./ElevationData");
+  m_dsaSettings[AppConstants::PROPERTYNAME_SIMULATION_DIRECTORY] = QStringLiteral("./SimulationData");
+  m_dsaSettings[LocationController::PROPERTY_NAME_RESOURCE_DIRECTORY] = QStringLiteral("./ResourceData");
+  m_dsaSettings[AppConstants::PROPERTYNAME_LOCAL_DATA_PATHS] = QStringList{ QStringLiteral("./OperationalData") };
   m_dsaSettings[AppConstants::PROPERTYNAME_DEFAULT_BASEMAP] = AppConstants::BASEMAP_NAME_TOPOGRAPHIC;
   m_dsaSettings[AppConstants::PROPERTYNAME_DEFAULT_ELEVATION_SOURCE] = QString("%1/CaDEM.tpk").arg(m_dsaSettings[AppConstants::PROPERTYNAME_ELEVATION_DIRECTORY].toString());
   m_dsaSettings[LocationController::PROPERTY_NAME_GPX_FILE] = QString("%1/MontereyMounted.gpx").arg(m_dsaSettings[AppConstants::PROPERTYNAME_SIMULATION_DIRECTORY].toString());
@@ -530,7 +522,7 @@ void DsaController::createDefaultSettings()
   m_dsaSettings[GridController::PROPERTY_NAME_GRID_VISIBLE] = GridController::GRID_VISIBLE_VALUE_DEFAULT;
   m_dsaSettings[GridController::PROPERTY_NAME_GRID_COLOR_SCHEME] = GridController::GRID_COLOR_SCHEME_VALUE_DEFAULT;
   writeDefaultConditions();
-  m_dsaSettings[OpenMobileScenePackageController::PACKAGE_DIRECTORY_PROPERTYNAME] = QString("%1/Packages").arg(m_dsaSettings[AppConstants::PROPERTYNAME_ROOT_DATA_DIRECTORY].toString());
+  m_dsaSettings[OpenMobileScenePackageController::PACKAGE_DIRECTORY_PROPERTYNAME] = QStringLiteral("./Packages");
 }
 
 /*!

--- a/Shared/DsaController.h
+++ b/Shared/DsaController.h
@@ -68,7 +68,6 @@ private:
   void setupConfig();
   void createDefaultSettings();
   void saveSettings();
-  void writeDefaultLocalDataPaths();
   void writeDefaultConditions();
   void writeDefaultMessageFeeds();
   bool isConflictingTool(const QString& toolName) const;

--- a/Shared/DsaUtility.h
+++ b/Shared/DsaUtility.h
@@ -35,6 +35,7 @@ public:
   inline static const QString FILE_NAME_APP_CONFIG = QStringLiteral("DsaAppConfig.json");
   inline static const QString FILE_NAME_DSA_CONFIGURATIONS = QStringLiteral("DsaConfigurations.json");
   inline static const QString FILE_PATH_HOME_DATA = QStringLiteral("ArcGIS/Runtime/Data/DSA");
+  inline static const QString FILE_PATH_CURRENT_DIRECTORY = QStringLiteral(".");
 
   static QString configurationsDirectoryPath();
   static QString configurationsFilePath();

--- a/Shared/configurations/ConfigurationController.cpp
+++ b/Shared/configurations/ConfigurationController.cpp
@@ -192,8 +192,7 @@ bool ConfigurationController::updateExtractedConfigurationFile(const QDir& confi
 
   // re-write the entire document with the old root directory replaced by the extracted location
   QString configString{configBytes};
-  const QString rootDataDirectoryNew{configurationDirectory.absolutePath()};
-  const QString configStringUpdated{configString.replace(rootDataDirectoryCleaned, rootDataDirectoryNew)};
+  const QString configStringUpdated{configString.replace(rootDataDirectoryCleaned, DsaUtility::FILE_PATH_CURRENT_DIRECTORY)};
   dsaAppConfigFile.write(configStringUpdated.toUtf8());
   return true;
 }

--- a/Shared/configurations/ConfigurationController.cpp
+++ b/Shared/configurations/ConfigurationController.cpp
@@ -184,7 +184,10 @@ bool ConfigurationController::updateExtractedConfigurationFile(const QDir& confi
     return false;
 
   // clean the path to make sure no trailing slashes are in the replacement string
+  // if the root directory value is anything other than the symbolic reference to the current directory '.'
   auto rootDataDirectoryCleaned = QDir::cleanPath(rootDataDirectoryVar.toString());
+  if (rootDataDirectoryCleaned == DsaUtility::FILE_PATH_CURRENT_DIRECTORY)
+    return true;
 
   // overwrite the app config file with the new json doc
   if (!dsaAppConfigFile.open(QIODevice::WriteOnly | QIODevice::Truncate))


### PR DESCRIPTION
Key to using relative paths is just to set the application's current directory `Shared/DsaController.cpp:103`. Once this is done, the Maps SDK data sources can work with relative or absolute paths in the config file.

#445