### PR TITLE
future needed unwrapping

### DIFF
--- a/Shared/alerts/AlertConditionsController.cpp
+++ b/Shared/alerts/AlertConditionsController.cpp
@@ -290,7 +290,7 @@ QFuture<bool> AlertConditionsController::addWithinDistanceAlert(const QString& c
 
     emit toolErrorOccurred(QStringLiteral("Failed to create Condition"), QString("Could not find source feed: %1").arg(sourceFeedName));
     return future_false;
-  }).result();
+  }).unwrap();
 }
 
 template<typename T>


### PR DESCRIPTION
In the removal of TaskWatcher, this QFuture was missed and needs to be unwrapped or the app will deadlock.