### PR TITLE
Dtedder/521 follow graphic null pointer error

### DIFF
--- a/Shared/ContextMenuController.cpp
+++ b/Shared/ContextMenuController.cpp
@@ -331,7 +331,7 @@ void ContextMenuController::processGeoElements()
   addOption(OPTION_IDENTIFY);
 
   quint8 pointGeoElementCount = 0;
-  GeoElement* lastPointGeoElementFound = nullptr;
+  const GeoElement* lastPointGeoElementFound = nullptr;
   for (const QList<GeoElement*>& geoElements : std::as_const(m_contextGeoElements))
   {
     for (const GeoElement* geoElement : geoElements)
@@ -352,7 +352,7 @@ void ContextMenuController::processGeoElements()
 
   if (pointGeoElementCount == 1) // if we have exactly 1 point GeoElement and it is a DynamicEntity, we can follow it
   {
-    if (const auto* de = dynamic_cast<DynamicEntity*>(lastPointGeoElementFound); de)
+    if (const auto* de = dynamic_cast<const DynamicEntity*>(lastPointGeoElementFound); de)
       addOption(OPTION_FOLLOW);
   }
 

--- a/Shared/ContextMenuController.cpp
+++ b/Shared/ContextMenuController.cpp
@@ -331,12 +331,14 @@ void ContextMenuController::processGeoElements()
   addOption(OPTION_IDENTIFY);
 
   quint8 pointGeoElementCount = 0;
-  for (const auto& geoElements : std::as_const(m_contextGeoElements))
+  GeoElement* lastPointGeoElementFound = nullptr;
+  for (const QList<GeoElement*>& geoElements : std::as_const(m_contextGeoElements))
   {
-    for (const auto* geoElement : geoElements)
+    for (const GeoElement* geoElement : geoElements)
     {
       if (geoElement->geometry().geometryType() == GeometryType::Point)
       {
+        lastPointGeoElementFound = geoElement;
         if (++pointGeoElementCount > 1)
           break;
       }
@@ -348,8 +350,11 @@ void ContextMenuController::processGeoElements()
       break;
   }
 
-  if (pointGeoElementCount == 1) // if we have exactly 1 point graphic, we can follow it
-    addOption(OPTION_FOLLOW);
+  if (pointGeoElementCount == 1) // if we have exactly 1 point GeoElement and it is a DynamicEntity, we can follow it
+  {
+    if (const auto* de = dynamic_cast<DynamicEntity*>(lastPointGeoElementFound); de)
+      addOption(OPTION_FOLLOW);
+  }
 
   if (pointGeoElementCount > 0) // if we have at least 1 point geometry, we can perform LOS
     addOption(OPTION_LINE_OF_SIGHT);


### PR DESCRIPTION
I was not able to reproduce this behavior following PR #515. But this update will not include `FOLLOW` in the context menu options unless the single entity that is identified is also a DynamicEntity/latest observation for a MessageFeedOverlay.