### PR TITLE
Popup definitions and location broadcast fix

### DIFF
--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -492,7 +492,10 @@ void DsaController::writeDefaultMessageFeeds()
   m_dsaSettings[MESSAGE_FEEDS_PROPERTYNAME] = messageFeedsJson;
 
   QJsonObject locationBroadcastJson;
-  locationBroadcastJson.insert(LOCATION_BROADCAST_CONFIG_MESSAGE_TYPE, QStringLiteral("position_report_land"));
+  // broadcast location should use the same message type as received position reports,
+  // but the feed type is `position_report_land`
+  //locationBroadcastJson.insert(LOCATION_BROADCAST_CONFIG_MESSAGE_TYPE, QStringLiteral("position_report_land"));
+  locationBroadcastJson.insert(LOCATION_BROADCAST_CONFIG_MESSAGE_TYPE, QStringLiteral("position_report"));
   locationBroadcastJson.insert(LOCATION_BROADCAST_CONFIG_PORT, 45679);
   m_dsaSettings[LOCATION_BROADCAST_CONFIG_PROPERTYNAME] = locationBroadcastJson;
 

--- a/Shared/IdentifyController.cpp
+++ b/Shared/IdentifyController.cpp
@@ -15,6 +15,7 @@
  ******************************************************************************/
 
 // PCH header
+#include "DynamicEntityObservation.h"
 #include "pch.hpp"
 
 #include "IdentifyController.h"
@@ -146,24 +147,62 @@ bool IdentifyController::addGeoElementPopup(GeoElement* geoElement, const QStrin
   if (!geoElement->attributes() || geoElement->attributes()->isEmpty())
     return false;
 
-  // check for dynamic entities
-  if (const auto* de = dynamic_cast<DynamicEntity*>(geoElement); de)
+  // check for dynamic entities or observations
+  if (dynamic_cast<const DynamicEntity*>(geoElement) != nullptr ||   // if (const auto* de = dynamic_cast<DynamicEntity*>(geoElement); de)
+      dynamic_cast<const DynamicEntityObservation*>(geoElement) != nullptr)
   {
     Popup* newPopup = nullptr;
-    if (const QVariant geoElementTypeV = geoElement->attributes()->attributeValue(MessageFeeds::Fields::GeoMessage::TYPE); geoElementTypeV.isValid())
+    const QVariant geoElementTypeV = geoElement->attributes()->attributeValue(MessageFeeds::Fields::GeoMessage::TYPE);
+    if (geoElementTypeV.isValid())
     {
       if (const QString popupDefinitionUrl = getPopupDefinitionUrlForMessageType(geoElementTypeV.toString()); !popupDefinitionUrl.isEmpty())
       {
+        // TODO: When the same popupDefinition is used for a DE and a DEO,
+        //      the title is overwritten so they end up being the same for both popups
+        //      We need to be able to create two different popup definitions in m_popupDefinitions
+        //      for position_report (DE) and position_report (DEO)
         if (PopupDefinition* popupDefinition = getPopupDefinitionForUrl(popupDefinitionUrl); popupDefinition)
-          newPopup = new Popup(geoElement, popupDefinition, this);
+        {
+          //Dynamic Entities popup
+          if (const auto* de = dynamic_cast<DynamicEntity*>(geoElement); de)
+          {
+            newPopup = new Popup(geoElement, popupDefinition, this);
+            newPopup->popupDefinition()->setTitle(popupTitle);
+            if (geoElementTypeV == MessageFeeds::Types::POSITION_REPORT)    // subtitle for dynamic DEs, position_reports only
+              newPopup->popupDefinition()->setTitle(QString{"%1<br><i><font size=\"4\" color=\"#68C1F9\">live track info</i>"}.arg(popupTitle));
+          }
+          else  // Observations popup
+          {
+            newPopup = new Popup(geoElement, popupDefinition, this);
+            newPopup->popupDefinition()->setTitle(popupTitle);
+            // subtitle for static DEOs, position_reports only (removing for now, might not want it)
+            //if (geoElementTypeV == MessageFeeds::Types::POSITION_REPORT)
+              //newPopup->popupDefinition()->setTitle(QString{"%1<br><i><font size=\"4\">previous observation)</i></font>"}.arg(popupTitle));
+          }
+        }
       }
     }
 
-    // default popup to be used for CoT types currently
+    // CoT Popup
+    // TODO: can probably clean this up and add to the logic above
     if (!newPopup)
-      newPopup = new Popup(geoElement, this);
+    {
+      if (const QString popupDefinitionUrl = getPopupDefinitionUrlForMessageType(MessageFeeds::Types::CURSOR_ON_TARGET); !popupDefinitionUrl.isEmpty())
+      {
+        if (PopupDefinition* popupDefinition = getPopupDefinitionForUrl(popupDefinitionUrl); popupDefinition)
+        {
+          newPopup = new Popup(geoElement, popupDefinition, this);
+          newPopup->popupDefinition()->setTitle(popupTitle);
+        }
+      }
+    }
 
-    newPopup->popupDefinition()->setTitle(QString{"%1<br>(Live Updates)"}.arg(popupTitle));
+    // default popup just in case
+    if (!newPopup) {
+      newPopup = new Popup(geoElement, this);
+      newPopup->popupDefinition()->setTitle(popupTitle);
+    }
+
     m_popups.push_back(newPopup);
     return true;
   }
@@ -211,8 +250,10 @@ bool IdentifyController::canPrev() const
 
 PopupDefinition* IdentifyController::getPopupDefinitionForUrl(const QString& url)
 {
-  if (m_popupDefinitions.find(url) == m_popupDefinitions.cend())
-  {
+// commented out for now, to test different popup titles for DEs and DEOs
+// TODO: need to create different popup definitions for DE and DEO, based on the same url
+// if (m_popupDefinitions.find(url) == m_popupDefinitions.cend())
+//  {
     qDebug() << "creating popup def for" << url;
     QFile fileGeoMessage{url};
     fileGeoMessage.open(QFile::ReadOnly);
@@ -262,10 +303,11 @@ PopupDefinition* IdentifyController::getPopupDefinitionForUrl(const QString& url
     pd->setExpressions(expressionInfos);
     pd->setFields(fieldInfos);
     pd->setTitle(popupInfo["title"].toString());
-    m_popupDefinitions[url] = pd;
-  }
+ //   m_popupDefinitions[url] = pd;
+ // }
 
-  return m_popupDefinitions[url];
+//  return m_popupDefinitions[url];
+  return pd;
 }
 
 Popup* IdentifyController::popup() const

--- a/Shared/LocationBroadcast.cpp
+++ b/Shared/LocationBroadcast.cpp
@@ -358,6 +358,7 @@ void LocationBroadcast::broadcastLocation()
 
     attribs.insert(MessageFeeds::Fields::GeoMessage::SIC, s_locationBroadcastSic);
     attribs.insert(MessageFeeds::Fields::GeoMessage::UNIQUE_DESIGNATION, m_userName);
+    attribs.insert(MessageFeeds::Fields::GeoMessage::ENVIRONMENT, "land");
     const int status911 = m_inDistress ? 1 : 0;
     attribs.insert(MessageFeeds::Fields::GeoMessage::STATUS_911, status911);
     m_message.setAttributes(attribs);

--- a/Shared/Resources/Resources.qrc
+++ b/Shared/Resources/Resources.qrc
@@ -80,5 +80,6 @@
         <file>messages/popupDefinitions/sensor_obs.json</file>
         <file>messages/popupDefinitions/sitrep.json</file>
         <file>messages/popupDefinitions/spotrep.json</file>
+        <file>messages/popupDefinitions/cot.json</file>
     </qresource>
 </RCC>

--- a/Shared/Resources/messages/popupDefinitions/cot.json
+++ b/Shared/Resources/messages/popupDefinitions/cot.json
@@ -1,0 +1,124 @@
+{"popupInfo": {
+    "popupElements": [
+        {
+            "type": "expression",
+            "expressionInfo": {
+                "title": "New expression",
+                "expression": "\nvar returnString= '<span style=\"font-size:12px;\"><i>Received: </i><b> {expression/expr1}</b></span>'\n\nreturn { type : 'text', text : returnString}",
+                "returnType": "dictionary"
+            }
+        },
+        {
+            "type": "fields",
+            "description": "",
+            "fieldInfos": [
+                {
+                    "fieldName": "expression/exprTypeVals",
+                    "isEditable": true,
+                    "visible": true
+                },
+                {
+                    "fieldName": "type",
+                    "isEditable": true,
+                    "label": "Event type code",
+                    "visible": true
+                },
+                {
+                    "fieldName": "time",
+                    "isEditable": true,
+                    "label": "Time created",
+                    "visible": true
+                },
+                {
+                    "fieldName": "start",
+                    "isEditable": true,
+                    "label": "Event start time",
+                    "visible": true
+                },
+                {
+                    "fieldName": "stale",
+                     "isEditable": true,
+                    "label": "Event expiration time",
+                    "visible": true
+                },
+                {
+                    "fieldName": "how",
+                    "isEditable": true,
+                    "label": "How position was determined",
+                    "visible": true
+                },
+                {
+                    "fieldName": "lat",
+					"fieldFormat": {
+						"type": "number",
+						"maximumFractionDigits": 6,
+						"minimumFractionDigits": 2,
+						"useGrouping": "never"
+					},
+                    "format": {
+                        "digitSeparator": false,
+                        "places": 2
+                    },
+                    "isEditable": true,
+                    "label": "Latitude",
+                    "visible": true
+                },
+                {
+                    "fieldName": "lon",
+					"fieldFormat": {
+						"type": "number",
+						"maximumFractionDigits": 6,
+						"minimumFractionDigits": 2,
+						"useGrouping": "never"
+					},
+                    "format": {
+                        "digitSeparator": false,
+                        "places": 2
+                    },
+                    "isEditable": true,
+                    "label": "Longitude",
+                    "visible": true
+                },
+                {
+                    "fieldName": "hae",
+                    "format": {
+                        "digitSeparator": false,
+                        "places": 2
+                    },
+                    "isEditable": true,
+                    "label": "Height/altitude",
+                    "visible": true
+                },
+                {
+                    "fieldName": "uid",
+                    "isEditable": true,
+                    "label": "Track ID",
+                    "visible": true
+                }
+            ],
+            "title": "Details:"
+        }
+    ],
+    "expressionInfos": [
+        {
+            "name": "expr0",
+            "title": "Time Received",
+            "expression": "Text(Date(TimeReceived($feature)), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
+            "returnType": "string"
+        },
+        {
+            "name": "expr1",
+            "title": "SYS_TIMESTAMP",
+            "expression": "Text(Date($feature.SYS_TIMESTAMP), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
+            "returnType": "string"
+        },
+		{
+			"name": "exprTypeVals",
+			"title": "Event type",
+            "expression": "var affiliation = Decode(Mid($feature.type, 2, 1), 'p', 'Pending','u', 'Unknown', 'a', 'Assumed friend', 'f', 'Friend','n', 'Neutral', 's', 'Suspect','h', 'Hostile','j', 'Joker','k', 'Faker','o', 'None specified','x', 'Other','Other');\r\nvar battleDimension = Decode(Mid($feature.type, 4, 1), 'P', 'Space','A', 'Air','G', 'Ground',  'S', 'Sea surface', 'U', 'Sea subsurface', 'X', 'Other', 'Other');\r\nreturn \"<b><i>Affiliation: </i></b>\" + affiliation + TextFormatting.NewLine + \"<br><b><i>Battle Dimension: </i></b>\" + battleDimension;",
+			"returnType": "string"
+		}
+   ],
+    "title": ""
+}
+}

--- a/Shared/Resources/messages/popupDefinitions/eod.json
+++ b/Shared/Resources/messages/popupDefinitions/eod.json
@@ -1,66 +1,119 @@
-{
-  "popupInfo": {
+{"popupInfo": {
     "popupElements": [
-      {
-        "type": "text",
-        "text": "<p><span style=\"font-size:18px;\"><span><strong>{uniquedesignation}</strong></span><strong>&nbsp;</strong></span>&nbsp;<br><span style=\"font-size:12px;\"><i><strong>Updated:</strong> <span>{expression/expr1}</span>&nbsp;</i></span></p><figure class=\"table\"><table style=\"border:1px solid hsl(0, 0%, 90%);\"><tbody><tr><td><strong>Coordinates:</strong></td><td>{_control_points}</td></tr></tbody></table></figure><p>&nbsp;</p><p><span style=\"font-size:12px;\"><i>Time Received: {expression/expr0}&nbsp;</i></span></p><p>&nbsp;</p>"
-      }
-    ],
-    "description": "<p><span style=\"font-size:18px;\"><span><strong>{uniquedesignation}</strong></span><strong>&nbsp;</strong></span>&nbsp;<br><span style=\"font-size:12px;\"><i><strong>Updated:</strong> <span>{expression/expr1}</span>&nbsp;</i></span></p><figure class=\"table\"><table style=\"border:1px solid hsl(0, 0%, 90%);\"><tbody><tr><td><strong>Coordinates:</strong></td><td>{_control_points}</td></tr></tbody></table></figure><p>&nbsp;</p><p><span style=\"font-size:12px;\"><i>Time Received: {expression/expr0}&nbsp;</i></span></p><p>&nbsp;</p>",
-    "expressionInfos": [
-      {
-        "name": "expr0",
-        "title": "Time Received",
-        "expression": "Text(Date(TimeReceived($feature)), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
-        "returnType": "string"
-      },
-      {
-        "name": "expr1",
-        "title": "SYS_TIMESTAMP",
-        "expression": "Text(Date($feature.SYS_TIMESTAMP), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
-        "returnType": "string"
-      }
-    ],
-    "fieldInfos": [
-      {
-        "fieldName": "sic",
-        "isEditable": true,
-        "label": "sic",
-        "visible": true
-      },
-      {
-        "fieldName": "status911",
-        "format": {
-          "digitSeparator": true,
-          "places": 0
+        {
+            "type": "expression",
+            "expressionInfo": {
+                "title": "New expression",
+                "expression": "\nvar returnString= '<span style=\"font-size:12px;\"><i>Reporting unit:</></span><br><span style=\"font-size:18px;color:#68C1F9\"><strong>{uniquedesignation}</strong></span><br><span style=\"font-size:12px;\"><i>Received: </i><b> {expression/expr1}</b></span>'\n\nreturn { type : 'text', text : returnString}",
+                "returnType": "dictionary"
+            }
         },
-        "isEditable": true,
-        "label": "status911",
-        "visible": true
-      },
-      {
-        "fieldName": "uniquedesignation",
-        "isEditable": true,
-        "label": "uniquedesignation",
-        "visible": true
-      },
-      {
-        "fieldName": "_control_points",
-        "isEditable": true,
-        "label": "control points",
-        "visible": true
-      },
-      {
-        "fieldName": "expression/expr0",
-        "isEditable": true,
-        "visible": true
-      },
-      {
-        "fieldName": "expression/expr1",
-        "isEditable": true,
-        "visible": true
-      }
+        {
+            "type": "fields",
+            "description": "",
+            "fieldInfos": [
+                {
+                    "fieldName": "datetimesubmitted",
+                    "isEditable": true,
+                    "label": "Datetime submitted",
+                    "visible": true
+                },
+                {
+                    "fieldName": "status",
+                    "isEditable": true,
+                    "label": "Status",
+                    "visible": true
+                },
+                {
+                    "fieldName": "nbc",
+                    "isEditable": true,
+                    "label": "NBC",
+                    "visible": true
+                },
+                {
+                    "fieldName": "incident_id",
+                     "isEditable": true,
+                    "label": "Incident ID",
+                    "visible": true
+                },
+                {
+                    "fieldName": "location",
+                    "isEditable": true,
+                    "label": "Location",
+                    "visible": true
+                },
+                {
+                    "fieldName": "location_desc",
+                    "isEditable": true,
+                    "label": "Location description",
+                    "visible": true
+                },
+                {
+                    "fieldName": "contact",
+                    "isEditable": true,
+                    "label": "Contact",
+                    "visible": true
+                },
+                {
+                    "fieldName": "nbc_type",
+                    "isEditable": true,
+                    "label": "NBC type",
+                    "visible": true
+                },
+                {
+                    "fieldName": "resources",
+                    "isEditable": true,
+                    "label": "Resources",
+                    "visible": true
+                },
+                {
+                    "fieldName": "impact",
+                    "isEditable": true,
+                    "label": "Impact",
+                    "visible": true
+                },
+                {
+                    "fieldName": "protective_meas",
+                    "isEditable": true,
+                    "label": "Protective measures",
+                    "visible": true
+                },
+                {
+                    "fieldName": "munition_type",
+                    "isEditable": true,
+                    "label": "Munition type",
+                    "visible": true
+                },
+                {
+                    "fieldName": "priority",
+                    "isEditable": true,
+                    "label": "Priority",
+                    "visible": true
+                },
+                {
+                    "fieldName": "_id",
+                    "isEditable": true,
+                    "label": "Track ID",
+                    "visible": true
+                }
+            ],
+            "title": "Report:"
+        }
     ],
-    "title": "GeoMessage Title"
-  }
+    "expressionInfos": [
+        {
+            "name": "expr0",
+            "title": "Time Received",
+            "expression": "Text(Date(TimeReceived($feature)), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
+            "returnType": "string"
+        },
+        {
+            "name": "expr1",
+            "title": "SYS_TIMESTAMP",
+            "expression": "Text(Date($feature.SYS_TIMESTAMP), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
+            "returnType": "string"
+        }
+    ],
+    "title": ""
+}
 }

--- a/Shared/Resources/messages/popupDefinitions/position_report.json
+++ b/Shared/Resources/messages/popupDefinitions/position_report.json
@@ -1,66 +1,89 @@
-{
-  "popupInfo": {
+{"popupInfo": {
     "popupElements": [
-      {
-        "type": "text",
-        "text": "<p><span style=\"font-size:18px;\"><span><strong>{uniquedesignation}</strong></span><strong>&nbsp;</strong></span>&nbsp;<br><span style=\"font-size:12px;\"><i><strong>Updated:</strong> <span>{expression/expr1}</span>&nbsp;</i></span></p><figure class=\"table\"><table style=\"border:1px solid hsl(0, 0%, 90%);\"><tbody><tr><td><strong>Coordinates:</strong></td><td>{_control_points}</td></tr></tbody></table></figure><p>&nbsp;</p><p><span style=\"font-size:12px;\"><i>Time Received: {expression/expr0}&nbsp;</i></span></p><p>&nbsp;</p>"
-      }
-    ],
-    "description": "<p><span style=\"font-size:18px;\"><span><strong>{uniquedesignation}</strong></span><strong>&nbsp;</strong></span>&nbsp;<br><span style=\"font-size:12px;\"><i><strong>Updated:</strong> <span>{expression/expr1}</span>&nbsp;</i></span></p><figure class=\"table\"><table style=\"border:1px solid hsl(0, 0%, 90%);\"><tbody><tr><td><strong>Coordinates:</strong></td><td>{_control_points}</td></tr></tbody></table></figure><p>&nbsp;</p><p><span style=\"font-size:12px;\"><i>Time Received: {expression/expr0}&nbsp;</i></span></p><p>&nbsp;</p>",
-    "expressionInfos": [
-      {
-        "name": "expr0",
-        "title": "Time Received",
-        "expression": "Text(Date(TimeReceived($feature)), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
-        "returnType": "string"
-      },
-      {
-        "name": "expr1",
-        "title": "SYS_TIMESTAMP",
-        "expression": "Text(Date($feature.SYS_TIMESTAMP), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
-        "returnType": "string"
-      }
-    ],
-    "fieldInfos": [
-      {
-        "fieldName": "sic",
-        "isEditable": true,
-        "label": "sic",
-        "visible": true
-      },
-      {
-        "fieldName": "status911",
-        "format": {
-          "digitSeparator": true,
-          "places": 0
+        {
+            "type": "expression",
+            "expressionInfo": {
+                "title": "New expression",
+                "expression": "\nvar returnString= '<span style=\"font-size:12px;\"><i>Reporting unit:</i></span><br><span style=\"font-size:18px;color:#68C1F9\"><strong>{uniquedesignation}</strong></span><br><span style=\"font-size:12px;\"><i>Received: </i><b> {expression/expr1}</b></span>'\n\nreturn { type : 'text', text : returnString}",
+                "returnType": "dictionary"
+            }
         },
-        "isEditable": true,
-        "label": "status911",
-        "visible": true
-      },
-      {
-        "fieldName": "uniquedesignation",
-        "isEditable": true,
-        "label": "uniquedesignation",
-        "visible": true
-      },
-      {
-        "fieldName": "_control_points",
-        "isEditable": true,
-        "label": "control points",
-        "visible": true
-      },
-      {
-        "fieldName": "expression/expr0",
-        "isEditable": true,
-        "visible": true
-      },
-      {
-        "fieldName": "expression/expr1",
-        "isEditable": true,
-        "visible": true
-      }
+        {
+            "type": "fields",
+            "description": "",
+            "fieldInfos": [
+                {
+                    "fieldName": "owningunit",
+                    "isEditable": true,
+                    "label": "Owning Unit",
+                    "visible": true
+                },
+                {
+                    "fieldName": "staffcomment",
+                    "isEditable": true,
+                    "label": "Staff Comment",
+                    "visible": true
+                },
+                {
+                    "fieldName": "speed",
+                    "format": {
+                        "digitSeparator": true,
+                        "places": 0
+                    },
+                    "isEditable": true,
+                    "label": "Speed",
+                    "visible": true
+                },
+                {
+                    "fieldName": "status911",
+                    "format": {
+                        "digitSeparator": true,
+                        "places": 0
+                    },
+                    "isEditable": true,
+                    "label": "Alert Status",
+                    "visible": true
+                },
+                {
+                    "fieldName": "sic",
+                    "isEditable": true,
+                    "label": "SIDC (2525c)",
+                    "visible": true
+                },
+                {
+                    "fieldName": "_control_points",
+                    "format": {
+                        "digitSeparator": false,
+                        "places": 2
+                    },
+                    "isEditable": true,
+                    "label": "Coordinates",
+                    "visible": true
+                },
+                {
+                    "fieldName": "_id",
+                    "isEditable": true,
+                    "label": "Track ID",
+                    "visible": true
+                }
+            ],
+            "title": "Details:"
+        }
     ],
-    "title": "GeoMessage Title"
-  }
+    "expressionInfos": [
+        {
+            "name": "expr0",
+            "title": "Time Received",
+            "expression": "Text(Date(TimeReceived($feature)), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
+            "returnType": "string"
+        },
+        {
+            "name": "expr1",
+            "title": "SYS_TIMESTAMP",
+            "expression": "Text(Date($feature.SYS_TIMESTAMP), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
+            "returnType": "string"
+        }
+    ],
+    "title": ""
+}
 }

--- a/Shared/Resources/messages/popupDefinitions/sensor_obs.json
+++ b/Shared/Resources/messages/popupDefinitions/sensor_obs.json
@@ -1,66 +1,77 @@
-{
-  "popupInfo": {
+{"popupInfo": {
     "popupElements": [
-      {
-        "type": "text",
-        "text": "<p><span style=\"font-size:18px;\"><span><strong>{uniquedesignation}</strong></span><strong>&nbsp;</strong></span>&nbsp;<br><span style=\"font-size:12px;\"><i><strong>Updated:</strong> <span>{expression/expr1}</span>&nbsp;</i></span></p><figure class=\"table\"><table style=\"border:1px solid hsl(0, 0%, 90%);\"><tbody><tr><td><strong>Coordinates:</strong></td><td>{_control_points}</td></tr></tbody></table></figure><p>&nbsp;</p><p><span style=\"font-size:12px;\"><i>Time Received: {expression/expr0}&nbsp;</i></span></p><p>&nbsp;</p>"
-      }
-    ],
-    "description": "<p><span style=\"font-size:18px;\"><span><strong>{uniquedesignation}</strong></span><strong>&nbsp;</strong></span>&nbsp;<br><span style=\"font-size:12px;\"><i><strong>Updated:</strong> <span>{expression/expr1}</span>&nbsp;</i></span></p><figure class=\"table\"><table style=\"border:1px solid hsl(0, 0%, 90%);\"><tbody><tr><td><strong>Coordinates:</strong></td><td>{_control_points}</td></tr></tbody></table></figure><p>&nbsp;</p><p><span style=\"font-size:12px;\"><i>Time Received: {expression/expr0}&nbsp;</i></span></p><p>&nbsp;</p>",
-    "expressionInfos": [
-      {
-        "name": "expr0",
-        "title": "Time Received",
-        "expression": "Text(Date(TimeReceived($feature)), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
-        "returnType": "string"
-      },
-      {
-        "name": "expr1",
-        "title": "SYS_TIMESTAMP",
-        "expression": "Text(Date($feature.SYS_TIMESTAMP), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
-        "returnType": "string"
-      }
-    ],
-    "fieldInfos": [
-      {
-        "fieldName": "sic",
-        "isEditable": true,
-        "label": "sic",
-        "visible": true
-      },
-      {
-        "fieldName": "status911",
-        "format": {
-          "digitSeparator": true,
-          "places": 0
+        {
+            "type": "expression",
+            "expressionInfo": {
+                "title": "New expression",
+                "expression": "\nvar returnString= '<span style=\"font-size:12px;\"><i>Sensor:</i></span><br><span style=\"font-size:18px;color:#68C1F9\"><strong>{uniquedesignation}</strong></span><br><span style=\"font-size:12px;\"><i>Received: </i><b> {expression/expr1}</b></span>'\n\nreturn { type : 'text', text : returnString}",
+                "returnType": "dictionary"
+            }
         },
-        "isEditable": true,
-        "label": "status911",
-        "visible": true
-      },
-      {
-        "fieldName": "uniquedesignation",
-        "isEditable": true,
-        "label": "uniquedesignation",
-        "visible": true
-      },
-      {
-        "fieldName": "_control_points",
-        "isEditable": true,
-        "label": "control points",
-        "visible": true
-      },
-      {
-        "fieldName": "expression/expr0",
-        "isEditable": true,
-        "visible": true
-      },
-      {
-        "fieldName": "expression/expr1",
-        "isEditable": true,
-        "visible": true
-      }
+        {
+            "type": "fields",
+            "description": "",
+            "fieldInfos": [
+                {
+                    "fieldName": "rel_info",
+                    "isEditable": true,
+                    "label": "Release info",
+                    "visible": true
+                },
+				{
+                    "fieldName": "created_by",
+                    "isEditable": true,
+                    "label": "Created by",
+                    "visible": true
+                },
+                {
+                    "fieldName": "created_at",
+                    "isEditable": true,
+                    "label": "Created at",
+                    "visible": true
+                },
+                {
+                    "fieldName": "edited_by",
+                    "isEditable": true,
+                    "label": "Edited by",
+                    "visible": true
+                },
+                {
+                    "fieldName": "edited_at",
+                     "isEditable": true,
+                    "label": "Edited at",
+                    "visible": true
+                },
+                {
+                    "fieldName": "prod_id",
+                    "isEditable": true,
+                    "label": "Prod ID",
+                    "visible": true
+                },
+                {
+                    "fieldName": "_id",
+                    "isEditable": true,
+                    "label": "Track ID",
+                    "visible": true
+                }
+            ],
+            "title": "Sensor obs:"
+        }
     ],
-    "title": "GeoMessage Title"
-  }
+    "expressionInfos": [
+        {
+            "name": "expr0",
+            "title": "Time Received",
+            "expression": "Text(Date(TimeReceived($feature)), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
+            "returnType": "string"
+        },
+        {
+            "name": "expr1",
+            "title": "SYS_TIMESTAMP",
+            "expression": "Text(Date($feature.SYS_TIMESTAMP), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
+            "returnType": "string"
+        }
+    ],
+    "title": ""
+}
 }

--- a/Shared/Resources/messages/popupDefinitions/sitrep.json
+++ b/Shared/Resources/messages/popupDefinitions/sitrep.json
@@ -1,66 +1,88 @@
-{
-  "popupInfo": {
+{"popupInfo": {
     "popupElements": [
-      {
-        "type": "text",
-        "text": "<p><span style=\"font-size:18px;\"><span><strong>{uniquedesignation}</strong></span><strong>&nbsp;</strong></span>&nbsp;<br><span style=\"font-size:12px;\"><i><strong>Updated:</strong> <span>{expression/expr1}</span>&nbsp;</i></span></p><figure class=\"table\"><table style=\"border:1px solid hsl(0, 0%, 90%);\"><tbody><tr><td><strong>Coordinates:</strong></td><td>{_control_points}</td></tr></tbody></table></figure><p>&nbsp;</p><p><span style=\"font-size:12px;\"><i>Time Received: {expression/expr0}&nbsp;</i></span></p><p>&nbsp;</p>"
-      }
-    ],
-    "description": "<p><span style=\"font-size:18px;\"><span><strong>{uniquedesignation}</strong></span><strong>&nbsp;</strong></span>&nbsp;<br><span style=\"font-size:12px;\"><i><strong>Updated:</strong> <span>{expression/expr1}</span>&nbsp;</i></span></p><figure class=\"table\"><table style=\"border:1px solid hsl(0, 0%, 90%);\"><tbody><tr><td><strong>Coordinates:</strong></td><td>{_control_points}</td></tr></tbody></table></figure><p>&nbsp;</p><p><span style=\"font-size:12px;\"><i>Time Received: {expression/expr0}&nbsp;</i></span></p><p>&nbsp;</p>",
-    "expressionInfos": [
-      {
-        "name": "expr0",
-        "title": "Time Received",
-        "expression": "Text(Date(TimeReceived($feature)), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
-        "returnType": "string"
-      },
-      {
-        "name": "expr1",
-        "title": "SYS_TIMESTAMP",
-        "expression": "Text(Date($feature.SYS_TIMESTAMP), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
-        "returnType": "string"
-      }
-    ],
-    "fieldInfos": [
-      {
-        "fieldName": "sic",
-        "isEditable": true,
-        "label": "sic",
-        "visible": true
-      },
-      {
-        "fieldName": "status911",
-        "format": {
-          "digitSeparator": true,
-          "places": 0
+        {
+            "type": "expression",
+            "expressionInfo": {
+                "title": "New expression",
+                "expression": "\nvar returnString= '<span style=\"font-size:12px;\"><i>Reporting unit:</i></span><br><span style=\"font-size:18px;color:#68C1F9\"><strong>{uniquedesignation}</strong></span><br><span style=\"font-size:12px;\"><i>Received: </i><b> {expression/expr1}</b></span>'\n\nreturn { type : 'text', text : returnString}",
+                "returnType": "dictionary"
+            }
         },
-        "isEditable": true,
-        "label": "status911",
-        "visible": true
-      },
-      {
-        "fieldName": "uniquedesignation",
-        "isEditable": true,
-        "label": "uniquedesignation",
-        "visible": true
-      },
-      {
-        "fieldName": "_control_points",
-        "isEditable": true,
-        "label": "control points",
-        "visible": true
-      },
-      {
-        "fieldName": "expression/expr0",
-        "isEditable": true,
-        "visible": true
-      },
-      {
-        "fieldName": "expression/expr1",
-        "isEditable": true,
-        "visible": true
-      }
+        {
+            "type": "fields",
+            "description": "",
+            "fieldInfos": [
+                {
+                    "fieldName": "activity",
+                    "isEditable": true,
+                    "label": "Activity",
+                    "visible": true
+                },
+                {
+                    "fieldName": "effective",
+                     "isEditable": true,
+                    "label": "Combat effectiveness",
+                    "visible": true
+                },
+                {
+                    "fieldName": "own_situation",
+                    "isEditable": true,
+                    "label": "Own situation disposition/status",
+                    "visible": true
+                },
+                {
+                    "fieldName": "situation_overview",
+                    "isEditable": true,
+                    "label": "Situation overview",
+                    "visible": true
+                },
+                {
+                    "fieldName": "operations",
+                    "isEditable": true,
+                    "label": "Operations",
+                    "visible": true
+                },
+                {
+                    "fieldName": "isr",
+                    "isEditable": true,
+                    "label": "Intelligence/reconnaissance",
+                    "visible": true
+                },
+                {
+                    "fieldName": "sustainment",
+                    "isEditable": true,
+                    "label": "Logistics",
+                    "visible": true
+                },
+                    "fieldName": "comms",
+                    "isEditable": true,
+                    "label": "Communications/connectivity",
+                    "visible": true
+                },
+                {
+                    "fieldName": "personnel",
+                    "isEditable": true,
+                    "label": "Personnel",
+                    "visible": true
+                },
+                {
+                    "fieldName": "_id",
+                    "isEditable": true,
+                    "label": "Track ID",
+                    "visible": true
+                }
+            ],
+            "title": "Situation Report:"
+        }
     ],
-    "title": "GeoMessage Title"
-  }
+    "expressionInfos": [
+        {
+            "name": "expr1",
+            "title": "SYS_TIMESTAMP",
+            "expression": "Text(Date($feature.SYS_TIMESTAMP), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
+            "returnType": "string"
+        }
+    ],
+    "title": ""
+}
 }

--- a/Shared/Resources/messages/popupDefinitions/spotrep.json
+++ b/Shared/Resources/messages/popupDefinitions/spotrep.json
@@ -1,66 +1,95 @@
-{
-  "popupInfo": {
+{"popupInfo": {
     "popupElements": [
-      {
-        "type": "text",
-        "text": "<p><span style=\"font-size:18px;\"><span><strong>{uniquedesignation}</strong></span><strong>&nbsp;</strong></span>&nbsp;<br><span style=\"font-size:12px;\"><i><strong>Updated:</strong> <span>{expression/expr1}</span>&nbsp;</i></span></p><figure class=\"table\"><table style=\"border:1px solid hsl(0, 0%, 90%);\"><tbody><tr><td><strong>Coordinates:</strong></td><td>{_control_points}</td></tr></tbody></table></figure><p>&nbsp;</p><p><span style=\"font-size:12px;\"><i>Time Received: {expression/expr0}&nbsp;</i></span></p><p>&nbsp;</p>"
-      }
-    ],
-    "description": "<p><span style=\"font-size:18px;\"><span><strong>{uniquedesignation}</strong></span><strong>&nbsp;</strong></span>&nbsp;<br><span style=\"font-size:12px;\"><i><strong>Updated:</strong> <span>{expression/expr1}</span>&nbsp;</i></span></p><figure class=\"table\"><table style=\"border:1px solid hsl(0, 0%, 90%);\"><tbody><tr><td><strong>Coordinates:</strong></td><td>{_control_points}</td></tr></tbody></table></figure><p>&nbsp;</p><p><span style=\"font-size:12px;\"><i>Time Received: {expression/expr0}&nbsp;</i></span></p><p>&nbsp;</p>",
-    "expressionInfos": [
-      {
-        "name": "expr0",
-        "title": "Time Received",
-        "expression": "Text(Date(TimeReceived($feature)), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
-        "returnType": "string"
-      },
-      {
-        "name": "expr1",
-        "title": "SYS_TIMESTAMP",
-        "expression": "Text(Date($feature.SYS_TIMESTAMP), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
-        "returnType": "string"
-      }
-    ],
-    "fieldInfos": [
-      {
-        "fieldName": "sic",
-        "isEditable": true,
-        "label": "sic",
-        "visible": true
-      },
-      {
-        "fieldName": "status911",
-        "format": {
-          "digitSeparator": true,
-          "places": 0
+        {
+            "type": "expression",
+            "expressionInfo": {
+                "title": "New expression",
+                "expression": "\nvar returnString= '<span style=\"font-size:12px;\"><i>Reporting unit:</i></span><br><span style=\"font-size:18px;color:#68C1F9\"><strong>{uniquedesignation}</strong></span><br><span style=\"font-size:12px;\"><i>Received: </i><b> {expression/expr1}</b></span>'\n\nreturn { type : 'text', text : returnString}",
+                "returnType": "dictionary"
+            }
         },
-        "isEditable": true,
-        "label": "status911",
-        "visible": true
-      },
-      {
-        "fieldName": "uniquedesignation",
-        "isEditable": true,
-        "label": "uniquedesignation",
-        "visible": true
-      },
-      {
-        "fieldName": "_control_points",
-        "isEditable": true,
-        "label": "control points",
-        "visible": true
-      },
-      {
-        "fieldName": "expression/expr0",
-        "isEditable": true,
-        "visible": true
-      },
-      {
-        "fieldName": "expression/expr1",
-        "isEditable": true,
-        "visible": true
-      }
+        {
+            "type": "fields",
+            "description": "",
+            "fieldInfos": [
+                {
+                    "fieldName": "size",
+                    "isEditable": true,
+                    "label": "Size",
+                    "visible": true
+                },
+                {
+                    "fieldName": "activity_cat",
+                    "isEditable": true,
+                    "label": "Activity (category)",
+                    "visible": true
+                },
+                {
+                    "fieldName": "activity",
+                    "isEditable": true,
+                    "label": "Activity",
+                    "visible": true
+                },
+                {
+                    "fieldName": "location",
+                     "isEditable": true,
+                    "label": "Location",
+                    "visible": true
+                },
+                {
+                    "fieldName": "unit_cat",
+                    "isEditable": true,
+                    "label": "Enemy Unit (category)",
+                    "visible": true
+                },
+                {
+                    "fieldName": "unit",
+                    "isEditable": true,
+                    "label": "Unit / Uniform",
+                    "visible": true
+                },
+                {
+                    "fieldName": "timeobserved",
+                    "isEditable": true,
+                    "label": "Time and Date",
+                    "visible": true
+                },
+                {
+                    "fieldName": "equip_cat",
+                    "isEditable": true,
+                    "label": "Equipment (category)",
+                    "visible": true
+                },
+                {
+                    "fieldName": "equipment",
+                    "isEditable": true,
+                    "label": "Equipment",
+                    "visible": true
+                },
+                {
+                    "fieldName": "_id",
+                    "isEditable": true,
+                    "label": "Track ID",
+                    "visible": true
+                }
+            ],
+            "title": "SALUTE Report:"
+        }
     ],
-    "title": "GeoMessage Title"
-  }
+    "expressionInfos": [
+        {
+            "name": "expr0",
+            "title": "Time Received",
+            "expression": "Text(Date(TimeReceived($feature)), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
+            "returnType": "string"
+        },
+        {
+            "name": "expr1",
+            "title": "SYS_TIMESTAMP",
+            "expression": "Text(Date($feature.SYS_TIMESTAMP), 'ddd, MMM D, Y @ H:mm:ss ZZZZ')",
+            "returnType": "string"
+        }
+    ],
+    "title": ""
+}
 }

--- a/Shared/Resources/messages/schemas/cot.json
+++ b/Shared/Resources/messages/schemas/cot.json
@@ -1,8 +1,8 @@
 {
   "name": "cot",
-  "version": "?",
+  "version": "2.0",
   "attribute_name_id": "uid",
-  "attribute_name_search": "uid",
+  "attribute_name_search": "type",
   "attributes": [
     {
       "type": "string",
@@ -23,6 +23,22 @@
     {
       "type": "string",
       "name": "hae"
+    },
+    {
+      "type": "string",
+      "name": "how"
+    },
+    {
+      "type": "string",
+      "name": "time"
+    },
+    {
+      "type": "string",
+      "name": "start"
+    },
+    {
+      "type": "string",
+      "name": "stale"
     }
   ]
 }

--- a/Shared/messages/Message.cpp
+++ b/Shared/messages/Message.cpp
@@ -207,6 +207,16 @@ Message Message::createFromCoTMessage(const QByteArray& message)
         // assign the unique message id
         cotMessage.d->messageId = attrs.value(MessageFeeds::Fields::CoT::UID).toString();
         attributes.insert(MessageFeeds::Fields::CoT::UID, cotMessage.d->messageId);
+
+        // Add other CoT attributes
+        const auto time = attrs.value(MessageFeeds::Fields::CoT::TIME).toString();
+        const auto start = attrs.value(MessageFeeds::Fields::CoT::START).toString();
+        const auto stale = attrs.value(MessageFeeds::Fields::CoT::STALE).toString();
+        const auto how = attrs.value(MessageFeeds::Fields::CoT::HOW).toString();
+        attributes.insert(MessageFeeds::Fields::CoT::HOW, how);
+        attributes.insert(MessageFeeds::Fields::CoT::TIME, time);
+        attributes.insert(MessageFeeds::Fields::CoT::START, start);
+        attributes.insert(MessageFeeds::Fields::CoT::STALE, stale);
       }
 
       // before reading other element tags, make sure we are parsing a CoT element

--- a/Shared/messages/MessageFeed.cpp
+++ b/Shared/messages/MessageFeed.cpp
@@ -523,6 +523,8 @@ bool MessageFeed::addMessage(const Message& message)
       return false;
     }
 
+    // TODO: validate attributes? message.attributes() will most likely have more than the DEDS schema
+
     addObservation(geometry, message.attributes());
   }
 

--- a/Shared/messages/MessageFeedConstants.h
+++ b/Shared/messages/MessageFeedConstants.h
@@ -106,6 +106,10 @@ inline static const QString UID   = QStringLiteral("uid");
 inline static const QString LAT   = QStringLiteral("lat");
 inline static const QString LON   = QStringLiteral("lon");
 inline static const QString HAE   = QStringLiteral("hae");
+inline static const QString HOW   = QStringLiteral("how");
+inline static const QString TIME   = QStringLiteral("time");
+inline static const QString START   = QStringLiteral("start");
+inline static const QString STALE   = QStringLiteral("stale");
 }
 namespace Dsa::MessageFeeds::Fields::GeoMessage {
 inline static const QString TYPE               = QStringLiteral("_type");


### PR DESCRIPTION
Several updates in this PR for you to consider and clean up. I put comments in the code, but the summary is: 

- Popup definitions. These are updated. Should be good for now, but will be easy to update if we want
- CoT popup and schema updates.  Added the popup definition and code to read it, also updated the schema to include some additional fields
- Change to test creating a popup with a separate popup title for DEs vs DEOs. I want to make sure the DE live updates are obvious from the previous observations.  The popup definition list is indexed by feed type, so they end up using the same title. It's working without using the list, so this fix still needs to be made to differentiate DE and DEO in the index.
- Location broadcast messages - updated so that the schema and values match the latest geomessage spec, so that the popup definition works on them as well as messages from the simulator
