### PR TITLE
Dtedder/534 multiple 2d button crash

### DIFF
--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -20,11 +20,9 @@
 #include "NavigationController.h"
 
 // C++ API headers
-#include "Basemap.h"
 #include "Camera.h"
 #include "ErrorException.h"
 #include "GlobeCameraController.h"
-#include "MapTypes.h"
 #include "OrbitGeoElementCameraController.h"
 #include "OrbitLocationCameraController.h"
 #include "Scene.h"

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -92,24 +92,25 @@ void NavigationController::updateGeoView()
   if (!m_geoView)
     return;
 
+  // There is currently no implementation for MapQuickView. This variable
+  // will remain false if any new features use something other than
+  // the SceneQuickView control.
   m_is3d = false;
+
   m_sceneView = dynamic_cast<SceneView*>(m_geoView);
   if (m_sceneView)
   {
     m_is3d = true;
 
-    Scene* scene = m_sceneView->arcGISScene();
-    if (!scene)
-    {
-      auto* sceneQV = static_cast<SceneQuickView*>(m_sceneView);
-      connect(sceneQV, &SceneQuickView::viewpointChanged, this, [this]()
-      {
-        center();
-      }, Qt::SingleShotConnection);
-      return;
-    }
-
-    center();
+    /*
+     * Note: This connection is only intended to capture a valid geometry
+     * for the center point for the controller once on app launch. This approach
+     * does not depend on operational or basemap data being loaded. It is not
+     * intended to verify that the layers/basemap or the scene itself are
+     * loaded and ready to be used.
+     */
+    auto* sceneQV = static_cast<SceneQuickView*>(m_sceneView);
+    connect(sceneQV, &SceneQuickView::viewpointChanged, this, &NavigationController::center, Qt::SingleShotConnection);
   }
 }
 

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -21,6 +21,7 @@
 
 // C++ API headers
 #include "Camera.h"
+#include "ErrorException.h"
 #include "GlobeCameraController.h"
 #include "OrbitGeoElementCameraController.h"
 #include "OrbitLocationCameraController.h"
@@ -287,6 +288,10 @@ void NavigationController::setRotationInternal()
  */
 void NavigationController::set2DInternal()
 {
+  static bool transitioningTo2D = false;
+  if (transitioningTo2D)
+    return;
+
   if (m_is3d)
   {
     // get the current camera
@@ -298,7 +303,17 @@ void NavigationController::set2DInternal()
     // rotate the camera using the delta pitch value
     const Camera newCamera = currentCamera.rotateAround(m_currentCenter, 0., -currentCamera.pitch(), 0.);
     // set the sceneview to the new camera
-    m_sceneView->setViewpointCameraAsync(newCamera, 2.0);
+    transitioningTo2D = true;
+    m_sceneView->setViewpointCameraAsync(newCamera, 2.0).then(this, [](bool)
+    {
+      transitioningTo2D = false;
+    }).onCanceled(this, []()
+    {
+      transitioningTo2D = false;
+    }).onFailed(this, [](const ErrorException&)
+    {
+      transitioningTo2D = false;
+    });
   }
 }
 

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -20,12 +20,15 @@
 #include "NavigationController.h"
 
 // C++ API headers
+#include "Basemap.h"
 #include "Camera.h"
 #include "ErrorException.h"
 #include "GlobeCameraController.h"
+#include "MapTypes.h"
 #include "OrbitGeoElementCameraController.h"
 #include "OrbitLocationCameraController.h"
 #include "Scene.h"
+#include "SceneQuickView.h"
 #include "SceneView.h"
 #include "SceneViewTypes.h"
 #include "Viewpoint.h"
@@ -91,15 +94,42 @@ void NavigationController::updateGeoView()
   if (!m_geoView)
     return;
 
+  m_is3d = false;
   m_sceneView = dynamic_cast<SceneView*>(m_geoView);
   if (m_sceneView)
   {
     m_is3d = true;
-  }
-  else
-  {
-    // set the mapView here
-    m_is3d = false;
+
+    // initialize the center point when the scene is loaded
+    Scene* scene = m_sceneView->arcGISScene();
+    if (!scene)
+    {
+      auto* sceneQV = static_cast<SceneQuickView*>(m_sceneView);
+      connect(sceneQV, &SceneQuickView::sceneChanged, this, [this]()
+      {
+        Scene* scene = m_sceneView->arcGISScene();
+        if (!scene)
+          return;
+
+        Basemap* basemap = scene->basemap();
+        if (!basemap)
+          return;
+
+        if (basemap->loadStatus() == LoadStatus::Loaded)
+        {
+          center();
+          return;
+        }
+
+        connect(basemap, &Basemap::doneLoading, this, [this](const Error& loadError)
+        {
+          if (!loadError.isEmpty())
+            return;
+
+          center();
+        }, Qt::SingleShotConnection);
+      }, Qt::SingleShotConnection);
+    }
   }
 }
 
@@ -333,7 +363,14 @@ void NavigationController::center()
     if (!m_enabled)
       return;
 
-    m_currentCenter = point;
+    // if the center of the screen does not intersect the globe and invalid point can be the result
+    // don't update the class property if this happens, fallback is the previous center point
+    if (!point.isEmpty() && point.isValid())
+      m_currentCenter = point;
+
+    // skip if center has never been initialized to a valid point
+    if (m_currentCenter.isEmpty() || !m_currentCenter.isValid())
+      return;
 
     if (m_currentMode == Mode::Zoom)
     {

--- a/Shared/NavigationController.cpp
+++ b/Shared/NavigationController.cpp
@@ -100,36 +100,18 @@ void NavigationController::updateGeoView()
   {
     m_is3d = true;
 
-    // initialize the center point when the scene is loaded
     Scene* scene = m_sceneView->arcGISScene();
     if (!scene)
     {
       auto* sceneQV = static_cast<SceneQuickView*>(m_sceneView);
-      connect(sceneQV, &SceneQuickView::sceneChanged, this, [this]()
+      connect(sceneQV, &SceneQuickView::viewpointChanged, this, [this]()
       {
-        Scene* scene = m_sceneView->arcGISScene();
-        if (!scene)
-          return;
-
-        Basemap* basemap = scene->basemap();
-        if (!basemap)
-          return;
-
-        if (basemap->loadStatus() == LoadStatus::Loaded)
-        {
-          center();
-          return;
-        }
-
-        connect(basemap, &Basemap::doneLoading, this, [this](const Error& loadError)
-        {
-          if (!loadError.isEmpty())
-            return;
-
-          center();
-        }, Qt::SingleShotConnection);
+        center();
       }, Qt::SingleShotConnection);
+      return;
     }
+
+    center();
   }
 }
 
@@ -355,15 +337,9 @@ void NavigationController::center()
   if (!m_sceneView)
     return;
 
-  m_enabled = true;
-
   m_sceneView->screenToLocationAsync(m_sceneView->widthInPixels() * 0.5, m_sceneView->heightInPixels() * 0.5).then(this, [this](Point point)
   {
-    // check if called from the navigation controls
-    if (!m_enabled)
-      return;
-
-    // if the center of the screen does not intersect the globe and invalid point can be the result
+    // if the center of the screen does not intersect the globe an invalid point can be the result
     // don't update the class property if this happens, fallback is the previous center point
     if (!point.isEmpty() && point.isValid())
       m_currentCenter = point;
@@ -384,11 +360,7 @@ void NavigationController::center()
     {
       set2DInternal();
     }
-
-    // reset
-    m_enabled = false;
   });
-
 }
 
 /*!

--- a/Shared/NavigationController.h
+++ b/Shared/NavigationController.h
@@ -89,7 +89,6 @@ private:
   double m_zoomFactor = 1.0;
   Esri::ArcGISRuntime::Point m_currentCenter;
   Mode m_currentMode;
-  bool m_enabled = false;
   bool m_isZoomIn = false;
   double m_cameraMoveDistance = 1000.0;
 };


### PR DESCRIPTION
prevent passing invalid points to the rotateAround method used in the 2D button on the navigation cluster.