### PR TITLE
set a parent for all the options in the coordinate conversion controller

### DIFF
--- a/Shared/CoordinateConversionToolProxy.cpp
+++ b/Shared/CoordinateConversionToolProxy.cpp
@@ -122,6 +122,16 @@ void CoordinateConversionToolProxy::toolInitProperties(const QVariantMap& proper
   if (!formats)
     return;
 
+  // manually set the available conversion option formats to be owned by the
+  // proxy so it will not be parented by the QQmlEngine. this may be fixed
+  // in a future release of the Toolkit.
+  for (int i = 0; i < formats->rowCount(); ++i)
+  {
+    QModelIndex index = formats->index(i);
+    if (QObject* o = formats->element<CoordinateConversionOption>(index); o)
+      o->setParent(this);
+  }
+
   auto findFormatIt = properties.find("CoordinateFormat");
   if (findFormatIt != properties.end())
   {


### PR DESCRIPTION
Not having a parent, the CoordinateConversionOption QObjects are being parented by the QQmlEngine. When the UI updates, the objects are being destroyed resulting in the combobox having few or no remaining options. This workaround sets the parent explicitly to the 'proxy' object so there will be no unintended disposal of the objects in the UI's model.