### PR TITLE
Dtedder/568 configuration updates 2

### DIFF
--- a/Handheld/qml/main.qml
+++ b/Handheld/qml/main.qml
@@ -653,7 +653,15 @@ Handheld {
         onAccepted: showConfigurations(true);
         onRejected: showConfigurations(false);
     }
+
+    property bool promptedForDefaultDownload: false
     function showConfigurations(downloadDefaultData) {
+        // prevents multiple 'Yes' taps.
+        // this dialog should only be shown on the initial startup.
+        if (promptedForDefaultDownload)
+            return;
+
+        promptedForDefaultDownload = true;
         if (downloadDefaultData)
             configurationController.downloadDefaultData();
 

--- a/Handheld/qml/main.qml
+++ b/Handheld/qml/main.qml
@@ -34,6 +34,7 @@ Handheld {
     property real hudRadius: 3 * scaleFactor
     property real hudMargins: 5 * scaleFactor
     property bool configurationsChanged: false
+    property bool promptedForDefaultDownload: false
 
     signal clearDialogAccepted();
     signal closeDialogAccepted();
@@ -654,7 +655,6 @@ Handheld {
         onRejected: showConfigurations(false);
     }
 
-    property bool promptedForDefaultDownload: false
     function showConfigurations(downloadDefaultData) {
         // prevents multiple 'Yes' taps.
         // this dialog should only be shown on the initial startup.

--- a/Handheld/qml/main.qml
+++ b/Handheld/qml/main.qml
@@ -649,7 +649,7 @@ Handheld {
 
     DsaYesNoDialog {
         id: configurationDownloadDialog
-        informativeText: "Download the default configuration data from Esri (~450mb)?"
+        informativeText: DsaResources.DefaultConfigurationDownloadPrompt
         onAccepted: showConfigurations(true);
         onRejected: showConfigurations(false);
     }

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -357,148 +357,20 @@ const DsaController* DsaController::instance()
  */
 void DsaController::setupConfig()
 {
-  // create the default settings map
-  createDefaultSettings();
-
   // get the app config
-  m_configFilePath = QString("%1/%2").arg(m_dsaSettings[AppConstants::PROPERTYNAME_ROOT_DATA_DIRECTORY].toString(), DsaUtility::FILE_NAME_APP_CONFIG);
+  m_configFilePath = QString("./%1").arg(DsaUtility::FILE_NAME_APP_CONFIG);
 
-  // If the config file does not exist, create it, and set all of the defaults
+  // if the config file does not exist, exit early to raise the prompt to download the default data folder
   if (!QFileInfo::exists(m_configFilePath))
-  {
-    saveSettings();
-  }
-  else
-  {
-    // Open the config file, get settings, set them to the application controller
-    QSettings settings(m_configFilePath, m_jsonFormat);
-    const QStringList allKeys = settings.allKeys();
+    return;
 
-    // get the values from the config, and write to the settings map
-    for (const QString& key : allKeys)
-      m_dsaSettings[key] = settings.value(key);
-  }
-}
+  // Open the config file, get settings, set them to the application controller
+  QSettings settings(m_configFilePath, m_jsonFormat);
+  const QStringList allKeys = settings.allKeys();
 
-/*! \brief internal
- *
- * Writes the default Alert Conditions as JSON to the settings map.
- */
-void DsaController::writeDefaultConditions()
-{
-  QJsonArray allConditionsJson;
-
-  // Add a condition "Distress" when an object from the Friendly Tracks Land feed has attribute status911 = 1
-  QJsonObject conditionJson;
-  conditionJson.insert(AlertConstants::CONDITION_NAME, QStringLiteral("Distress"));
-  conditionJson.insert(AlertConstants::CONDITION_LEVEL, static_cast<int>(AlertLevel::Critical));
-  conditionJson.insert(AlertConstants::CONDITION_TYPE, AlertConstants::attributeEqualsAlertConditionType());
-  conditionJson.insert(AlertConstants::CONDITION_SOURCE, QStringLiteral("Friendly Tracks - Land"));
-  QJsonObject queryObject;
-  queryObject.insert(AlertConstants::ATTRIBUTE_NAME, QStringLiteral("status911"));
-  conditionJson.insert(AlertConstants::CONDITION_QUERY, queryObject);
-  conditionJson.insert(AlertConstants::CONDITION_TARGET, "1");
-  allConditionsJson.append(conditionJson);
-  m_dsaSettings.insert(AlertConstants::ALERT_CONDITIONS_PROPERTYNAME, allConditionsJson.toVariantList());
-}
-
-/*! \brief internal
- *
- * Writes the default message feeds to the settings map.
- */
-void DsaController::writeDefaultMessageFeeds()
-{
-  using namespace Dsa::MessageFeedConstants;
-  m_dsaSettings[MESSAGE_FEED_UDP_PORTS_PROPERTYNAME] = QVariantList{ 45678, 45679 };
-
-  QJsonArray messageFeedsJson;
-
-  // create the default track display properties
-  const std::vector<std::tuple<QString, QVariant>> trackDisplayDefaults{
-    { MESSAGE_FEEDS_OBSERVATIONS_SHOW, false },
-    { MESSAGE_FEEDS_OBSERVATIONS_COLOR, MESSAGE_FEEDS_TRACK_DISPLAY_COLOR_DEFAULT },
-    { MESSAGE_FEEDS_OBSERVATIONS_SIZE, 10 },
-    { MESSAGE_FEEDS_OBSERVATIONS_MAXIMUM, 5 },
-    { MESSAGE_FEEDS_TRACK_LINE_SHOW, false },
-    { MESSAGE_FEEDS_TRACK_LINE_COLOR, MESSAGE_FEEDS_TRACK_DISPLAY_COLOR_DEFAULT },
-    { MESSAGE_FEEDS_TRACK_LINE_SIZE, 4 },
-  };
-  const auto itBeg = std::cbegin(trackDisplayDefaults);
-  const auto itEnd = std::cend(trackDisplayDefaults);
-  const auto appendAndAddTrackDisplayDefaults = [&](QJsonObject& o)
-  {
-    std::for_each(itBeg, itEnd, [&](const std::tuple<QString, QVariant>& t)
-    {
-      o.insert(std::get<0>(t), QJsonValue::fromVariant(std::get<1>(t)));
-    });
-    messageFeedsJson.append(o);
-  };
-
-  QJsonObject cotMessageFeedJson;
-  cotMessageFeedJson.insert(MESSAGE_FEEDS_NAME, QStringLiteral("SA Events"));
-  cotMessageFeedJson.insert(MESSAGE_FEEDS_TYPE, MessageFeeds::Types::CURSOR_ON_TARGET);
-  cotMessageFeedJson.insert(MESSAGE_FEEDS_RENDERER, QStringLiteral("mil2525c"));
-  cotMessageFeedJson.insert(MESSAGE_FEEDS_THUMBNAIL, QStringLiteral("saevents.png"));
-  cotMessageFeedJson.insert(MESSAGE_FEEDS_PLACEMENT, MESSAGE_FEEDS_PLACEMENT_DEFAULT);
-  appendAndAddTrackDisplayDefaults(cotMessageFeedJson);
-
-  QJsonObject friendlyTracksLandJson;
-  friendlyTracksLandJson.insert(MESSAGE_FEEDS_NAME, QStringLiteral("Friendly Tracks - Land"));
-  friendlyTracksLandJson.insert(MESSAGE_FEEDS_TYPE, QString{"%1_land"}.arg(MessageFeeds::Types::POSITION_REPORT));
-  friendlyTracksLandJson.insert(MESSAGE_FEEDS_RENDERER, QStringLiteral("mil2525c"));
-  friendlyTracksLandJson.insert(MESSAGE_FEEDS_THUMBNAIL, QStringLiteral("friendlytracks.png"));
-  friendlyTracksLandJson.insert(MESSAGE_FEEDS_PLACEMENT, MESSAGE_FEEDS_PLACEMENT_DEFAULT);
-  appendAndAddTrackDisplayDefaults(friendlyTracksLandJson);
-
-  QJsonObject friendlyTracksAirJson;
-  friendlyTracksAirJson.insert(MESSAGE_FEEDS_NAME, QStringLiteral("Friendly Tracks - Air"));
-  friendlyTracksAirJson.insert(MESSAGE_FEEDS_TYPE, QString{"%1_air"}.arg(MessageFeeds::Types::POSITION_REPORT));
-  friendlyTracksAirJson.insert(MESSAGE_FEEDS_RENDERER, QStringLiteral("mil2525c"));
-  friendlyTracksAirJson.insert(MESSAGE_FEEDS_THUMBNAIL, QStringLiteral("friendlytracks-air.png"));
-  friendlyTracksAirJson.insert(MESSAGE_FEEDS_PLACEMENT, QStringLiteral("absolute"));
-  appendAndAddTrackDisplayDefaults(friendlyTracksAirJson);
-
-  QJsonObject spotRepJson;
-  spotRepJson.insert(MESSAGE_FEEDS_NAME, QStringLiteral("Observation Reports"));
-  spotRepJson.insert(MESSAGE_FEEDS_TYPE, MessageFeeds::Types::SPOTREP);
-  spotRepJson.insert(MESSAGE_FEEDS_RENDERER, QStringLiteral("observation1600.png"));
-  spotRepJson.insert(MESSAGE_FEEDS_THUMBNAIL, QStringLiteral("observation1600.png"));
-  spotRepJson.insert(MESSAGE_FEEDS_PLACEMENT, MESSAGE_FEEDS_PLACEMENT_DEFAULT);
-  appendAndAddTrackDisplayDefaults(spotRepJson);
-
-  QJsonObject sitRepJson;
-  sitRepJson.insert(MESSAGE_FEEDS_NAME, QStringLiteral("Situation Reports"));
-  sitRepJson.insert(MESSAGE_FEEDS_TYPE, MessageFeeds::Types::SITREP);
-  sitRepJson.insert(MESSAGE_FEEDS_RENDERER, QStringLiteral("sitrep1600.png"));
-  sitRepJson.insert(MESSAGE_FEEDS_THUMBNAIL, QStringLiteral("sitrep1600.png"));
-  sitRepJson.insert(MESSAGE_FEEDS_PLACEMENT, MESSAGE_FEEDS_PLACEMENT_DEFAULT);
-  appendAndAddTrackDisplayDefaults(sitRepJson);
-
-  QJsonObject eodReportsJson;
-  eodReportsJson.insert(MESSAGE_FEEDS_NAME, QStringLiteral("EOD Reports"));
-  eodReportsJson.insert(MESSAGE_FEEDS_TYPE, MessageFeeds::Types::EOD);
-  eodReportsJson.insert(MESSAGE_FEEDS_RENDERER, QStringLiteral("eod1600.png"));
-  eodReportsJson.insert(MESSAGE_FEEDS_THUMBNAIL, QStringLiteral("eod1600.png"));
-  eodReportsJson.insert(MESSAGE_FEEDS_PLACEMENT, MESSAGE_FEEDS_PLACEMENT_DEFAULT);
-  appendAndAddTrackDisplayDefaults(eodReportsJson);
-
-  QJsonObject sensorObsJson;
-  sensorObsJson.insert(MESSAGE_FEEDS_NAME, QStringLiteral("Sensor Observations"));
-  sensorObsJson.insert(MESSAGE_FEEDS_TYPE, MessageFeeds::Types::SENSOR_OBS);
-  sensorObsJson.insert(MESSAGE_FEEDS_RENDERER, QStringLiteral("sensorobs1600.png"));
-  sensorObsJson.insert(MESSAGE_FEEDS_THUMBNAIL, QStringLiteral("sensorobs1600.png"));
-  sensorObsJson.insert(MESSAGE_FEEDS_PLACEMENT, MESSAGE_FEEDS_PLACEMENT_DEFAULT);
-  appendAndAddTrackDisplayDefaults(sensorObsJson);
-  m_dsaSettings[MESSAGE_FEEDS_PROPERTYNAME] = messageFeedsJson;
-
-  QJsonObject locationBroadcastJson;
-  locationBroadcastJson.insert(LOCATION_BROADCAST_CONFIG_MESSAGE_TYPE, QString{"%1_land"}.arg(MessageFeeds::Types::POSITION_REPORT));
-  locationBroadcastJson.insert(LOCATION_BROADCAST_CONFIG_PORT, 45679);
-  m_dsaSettings[LOCATION_BROADCAST_CONFIG_PROPERTYNAME] = locationBroadcastJson;
-
-  QJsonObject observationReportJson;
-  observationReportJson.insert(OBSERVATION_REPORT_CONFIG_PORT, 45679);
-  m_dsaSettings[OBSERVATION_REPORT_CONFIG_PROPERTYNAME] = observationReportJson;
+  // get the values from the config, and write to the settings map
+  for (const QString& key : allKeys)
+    m_dsaSettings[key] = settings.value(key);
 }
 
 /*! \brief internal
@@ -510,41 +382,6 @@ void DsaController::writeDefaultMessageFeeds()
 bool DsaController::isConflictingTool(const QString& toolName) const
 {
   return m_conflictingToolNames.contains(toolName);
-}
-
-/*! \brief internal
- *
- * This creates the default values for the config file. If the app
- * starts and there is no config file, it will create one, and write
- * the following values to the file.
- */
-void DsaController::createDefaultSettings()
-{
-  // setup the defaults
-  m_dsaSettings[AppConstants::PROPERTYNAME_ROOT_DATA_DIRECTORY] = DsaUtility::FILE_PATH_CURRENT_DIRECTORY;
-  m_dsaSettings[AppConstants::PROPERTYNAME_USERNAME] = QHostInfo::localHostName();
-  m_dsaSettings[AppConstants::PROPERTYNAME_BASEMAP_DIRECTORY] = QStringLiteral("./BasemapData");
-  m_dsaSettings[AppConstants::PROPERTYNAME_ELEVATION_DIRECTORY] = QStringLiteral("./ElevationData");
-  m_dsaSettings[AppConstants::PROPERTYNAME_SIMULATION_DIRECTORY] = QStringLiteral("./SimulationData");
-  m_dsaSettings[LocationController::PROPERTY_NAME_RESOURCE_DIRECTORY] = QStringLiteral("./ResourceData");
-  m_dsaSettings[AppConstants::PROPERTYNAME_LOCAL_DATA_PATHS] = QStringList{ QStringLiteral("./OperationalData") };
-  m_dsaSettings[AppConstants::PROPERTYNAME_DEFAULT_BASEMAP] = AppConstants::BASEMAP_NAME_TOPOGRAPHIC;
-  m_dsaSettings[AppConstants::PROPERTYNAME_DEFAULT_ELEVATION_SOURCE] = QString("%1/CaDEM.tpk").arg(m_dsaSettings[AppConstants::PROPERTYNAME_ELEVATION_DIRECTORY].toString());
-  m_dsaSettings[LocationController::PROPERTY_NAME_GPX_FILE] = QString("%1/MontereyMounted.gpx").arg(m_dsaSettings[AppConstants::PROPERTYNAME_SIMULATION_DIRECTORY].toString());
-  m_dsaSettings[LocationController::PROPERTY_NAME_SIMULATE_LOCATION] = AppConstants::BOOL_TRUE;
-  m_dsaSettings[LocationController::PROPERTY_NAME_CURRENT_LOCATION_Z_OFFSET] = QStringLiteral("10");
-  m_dsaSettings[LocationController::PROPERTY_NAME_CURRENT_LOCATION_SURFACE_PLACEMENT] = QStringLiteral("Relative");
-  writeDefaultMessageFeeds();
-  m_dsaSettings[AppConstants::PROPERTYNAME_COORDINATE_FORMAT] = Esri::ArcGISRuntime::Toolkit::CoordinateConversionConstants::MGRS_FORMAT;
-  m_dsaSettings[AppConstants::PROPERTYNAME_UNIT_OF_MEASUREMENT] = AppConstants::UNIT_METERS;
-  m_dsaSettings[AppConstants::PROPERTYNAME_USE_GPS_FOR_ELEVATION] = AppConstants::BOOL_TRUE;
-  QJsonObject markupJson;
-  markupJson.insert(QStringLiteral("port"), 45680);
-  m_dsaSettings[AppConstants::PROPERTYNAME_MARKUP_CONFIG] = markupJson;
-  m_dsaSettings[GridController::PROPERTY_NAME_GRID_VISIBLE] = GridController::GRID_VISIBLE_VALUE_DEFAULT;
-  m_dsaSettings[GridController::PROPERTY_NAME_GRID_COLOR_SCHEME] = GridController::GRID_COLOR_SCHEME_VALUE_DEFAULT;
-  writeDefaultConditions();
-  m_dsaSettings[OpenMobileScenePackageController::PACKAGE_DIRECTORY_PROPERTYNAME] = QStringLiteral("./Packages");
 }
 
 /*!

--- a/Shared/DsaController.cpp
+++ b/Shared/DsaController.cpp
@@ -357,20 +357,23 @@ const DsaController* DsaController::instance()
  */
 void DsaController::setupConfig()
 {
-  // get the app config
-  m_configFilePath = QString("./%1").arg(DsaUtility::FILE_NAME_APP_CONFIG);
-
   // if the config file does not exist, exit early to raise the prompt to download the default data folder
-  if (!QFileInfo::exists(m_configFilePath))
+  const auto configFilePath = QString{"./%1"}.arg(DsaUtility::FILE_NAME_APP_CONFIG);
+  if (!QFileInfo::exists(configFilePath))
+  {
     return;
+  }
 
   // Open the config file, get settings, set them to the application controller
-  QSettings settings(m_configFilePath, m_jsonFormat);
+  m_configFilePath = configFilePath;
+  const QSettings settings{m_configFilePath, m_jsonFormat};
   const QStringList allKeys = settings.allKeys();
 
   // get the values from the config, and write to the settings map
   for (const QString& key : allKeys)
+  {
     m_dsaSettings[key] = settings.value(key);
+  }
 }
 
 /*! \brief internal
@@ -389,12 +392,16 @@ bool DsaController::isConflictingTool(const QString& toolName) const
  */
 void DsaController::saveSettings()
 {
-  QSettings settings(m_configFilePath, m_jsonFormat);
+  if (m_configFilePath.isNull() || m_configFilePath.isEmpty())
+  {
+    return;
+  }
 
-  auto it = m_dsaSettings.cbegin();
-  auto itEnd = m_dsaSettings.cend();
-  for (; it != itEnd; ++it)
-    settings.setValue(it.key(), it.value());
+  QSettings settings(m_configFilePath, m_jsonFormat);
+  std::for_each(m_dsaSettings.constKeyValueBegin(), m_dsaSettings.constKeyValueEnd(), [&](const std::pair<QString, QVariant>& kv)
+  {
+    settings.setValue(kv.first, kv.second);
+  });
 }
 
 void DsaController::writeInitialLocation(const Viewpoint& viewpoint)

--- a/Shared/DsaController.h
+++ b/Shared/DsaController.h
@@ -66,10 +66,7 @@ signals:
 private:
   static inline const DsaController* s_instance = nullptr;
   void setupConfig();
-  void createDefaultSettings();
   void saveSettings();
-  void writeDefaultConditions();
-  void writeDefaultMessageFeeds();
   bool isConflictingTool(const QString& toolName) const;
   void updateInitialLocationOnSceneChange(bool isInitialization);
 

--- a/Shared/DsaResources.cpp
+++ b/Shared/DsaResources.cpp
@@ -68,6 +68,11 @@ QString DsaResources::arcGISMapsSDKVersion() const
   return m_arcGISMapsSDKVersion;
 }
 
+QString DsaResources::defaultConfigurationDownloadPrompt() const
+{
+  return QStringLiteral("Download the default configuration data from Esri?");
+}
+
 /*!
   \brief Returns the URL to the "2D" icon.
  */

--- a/Shared/DsaResources.cpp
+++ b/Shared/DsaResources.cpp
@@ -70,7 +70,7 @@ QString DsaResources::arcGISMapsSDKVersion() const
 
 QString DsaResources::defaultConfigurationDownloadPrompt() const
 {
-  return QStringLiteral("Download the default configuration data from Esri?");
+  return QStringLiteral("App configuration data not found.\n\nDownload the default configuration data from Esri?");
 }
 
 /*!

--- a/Shared/DsaResources.h
+++ b/Shared/DsaResources.h
@@ -28,6 +28,7 @@ class DsaResources : public QObject
   Q_OBJECT
 
   Q_PROPERTY(QString ArcGISMapsSDKVersion READ arcGISMapsSDKVersion NOTIFY arcGISMapsSDKVersionChanged)
+  Q_PROPERTY(QString DefaultConfigurationDownloadPrompt READ defaultConfigurationDownloadPrompt CONSTANT)
   Q_PROPERTY(QStringList TrackDisplayColors READ trackDisplayColors CONSTANT)
   Q_PROPERTY(QUrl icon2d READ icon2d CONSTANT)
   Q_PROPERTY(QUrl icon3d READ icon3d CONSTANT)
@@ -100,6 +101,7 @@ signals:
 private:
   QString m_arcGISMapsSDKVersion;
   QString arcGISMapsSDKVersion() const;
+  QString defaultConfigurationDownloadPrompt() const;
   QStringList trackDisplayColors();
   QUrl icon2d() const;
   QUrl icon3d() const;

--- a/Shared/configurations/Configuration.cpp
+++ b/Shared/configurations/Configuration.cpp
@@ -70,6 +70,7 @@ QUrl Configuration::url() const
 void Configuration::download()
 {
   m_downloadCancelled = false;
+  m_downloading = true;
   m_percentDownloaded = 0;
   m_percentExtracted = 0;
 }
@@ -81,7 +82,7 @@ bool Configuration::downloaded() const
 
 bool Configuration::downloading() const
 {
-  return m_percentDownloaded > 0 && m_percentDownloaded < 100;
+  return m_downloading;
 }
 
 bool Configuration::extracted() const
@@ -141,7 +142,11 @@ int Configuration::percentDownloaded() const
 
 void Configuration::setPercentDownloaded(int percentDownloaded)
 {
+  if (m_percentDownloaded == percentDownloaded)
+    return;
+
   m_percentDownloaded = percentDownloaded;
+  m_downloading = m_percentDownloaded > 0 && m_percentDownloaded < 100;
 }
 
 int Configuration::percentExtracted() const
@@ -169,6 +174,7 @@ void Configuration::cancelDownload()
 {
   setPercentDownloaded(0);
   setPercentExtracted(0);
+  m_downloading = false;
   m_downloadCancelled = true;
 }
 

--- a/Shared/configurations/Configuration.h
+++ b/Shared/configurations/Configuration.h
@@ -72,6 +72,7 @@ private:
   bool m_selected = false;
   bool m_loaded = false;
   bool m_isCancellable = true;
+  bool m_downloading = false;
   int m_percentDownloaded = 0;
   bool m_downloadCancelled = false;
   int m_percentExtracted = 0;

--- a/Shared/configurations/ConfigurationController.cpp
+++ b/Shared/configurations/ConfigurationController.cpp
@@ -123,11 +123,6 @@ void ConfigurationController::extractConfigurationDownload(const QString& downlo
     if (updateExtractedConfigurationFile(configurationDirectory))
       return;
 
-    // still exit early if the configuration is the default download from Esri
-    const auto configuration = m_configurationListModel->byName(configurationName);
-    if (configuration.urlStr() == ConfigurationController::DEFAULT_DOWNLOAD_URL)
-      return;
-
     // cleanup unusable files and reset the model item for the UI
     resetConfigurationDeviceStatus(configurationName);
 
@@ -161,9 +156,7 @@ void ConfigurationController::extractConfigurationDownload(const QString& downlo
 
 bool ConfigurationController::updateExtractedConfigurationFile(const QDir& configurationDirectory)
 {
-  // any download other than the default from Esri should have it's own DsaAppConfig.json
-  // file present. if it is not present, the default will be created when the app is
-  // relaunched with this configuration selected.
+  // all downloads are required to contain the DsaAppConfig.json in the expected location
   const auto dsaAppConfigFilePath = configurationDirectory.absoluteFilePath(DsaUtility::FILE_NAME_APP_CONFIG);
   QFile dsaAppConfigFile{dsaAppConfigFilePath};
   if (!dsaAppConfigFile.exists() || !dsaAppConfigFile.open(QIODevice::ReadOnly))

--- a/Shared/configurations/ConfigurationController.cpp
+++ b/Shared/configurations/ConfigurationController.cpp
@@ -319,6 +319,8 @@ void ConfigurationController::download(int index)
   if (configuration.downloading())
     return;
 
+  m_configurationListModel->download(configuration.name());
+
 #ifdef Q_OS_ANDROID
   if (configurationUrl.scheme() == QStringLiteral("content"))
   {

--- a/Shared/configurations/ConfigurationController.cpp
+++ b/Shared/configurations/ConfigurationController.cpp
@@ -286,6 +286,7 @@ void ConfigurationController::zipHeadReply_finished(QNetworkRequest zipRequest, 
     {
       removeDownloadedFile(downloadFilePath);
       resetConfigurationDeviceStatus(configurationName);
+      m_configurationListModel->cancel(configurationName);
       return;
     }
 
@@ -294,7 +295,10 @@ void ConfigurationController::zipHeadReply_finished(QNetworkRequest zipRequest, 
   connect(contentReply, &QNetworkReply::errorOccurred, this, [this, configurationName](QNetworkReply::NetworkError error)
   {
     if (error != QNetworkReply::NetworkError::OperationCanceledError)
+    {
+      m_configurationListModel->cancel(configurationName);
       sendRemoveConfigurationSignal(configurationName, QStringLiteral("The configuration zip failed to download."));
+    }
   });
 }
 

--- a/Shared/configurations/ConfigurationController.cpp
+++ b/Shared/configurations/ConfigurationController.cpp
@@ -315,6 +315,10 @@ void ConfigurationController::download(int index)
   const auto configurationUrlStr = configuration.urlStr();
   const auto configurationName = configuration.name();
 
+  // prevent double taps of the download icon from any potential UI lag
+  if (configuration.downloading())
+    return;
+
 #ifdef Q_OS_ANDROID
   if (configurationUrl.scheme() == QStringLiteral("content"))
   {

--- a/Shared/configurations/ConfigurationController.h
+++ b/Shared/configurations/ConfigurationController.h
@@ -43,7 +43,8 @@ class ConfigurationListModel;
 
 class ConfigurationController : public AbstractTool
 {
-  inline static const QString DEFAULT_DOWNLOAD_URL = QStringLiteral("https://www.arcgis.com/sharing/rest/content/items/02daf003b91348f5a761816e80cc39b5/data");
+  // inline static const QString DEFAULT_DOWNLOAD_URL = QStringLiteral("https://www.arcgis.com/sharing/rest/content/items/02daf003b91348f5a761816e80cc39b5/data");
+  inline static const QString DEFAULT_DOWNLOAD_URL = QStringLiteral("https://www.arcgis.com/sharing/rest/content/items/64075eb33ab24e7694214f2341a05052/data");
   inline static const QString DEFAULT_DOWNLOAD_NAME = QStringLiteral("Default");
 
   Q_OBJECT

--- a/Shared/configurations/ConfigurationController.h
+++ b/Shared/configurations/ConfigurationController.h
@@ -43,7 +43,6 @@ class ConfigurationListModel;
 
 class ConfigurationController : public AbstractTool
 {
-  // inline static const QString DEFAULT_DOWNLOAD_URL = QStringLiteral("https://www.arcgis.com/sharing/rest/content/items/02daf003b91348f5a761816e80cc39b5/data");
   inline static const QString DEFAULT_DOWNLOAD_URL = QStringLiteral("https://www.arcgis.com/sharing/rest/content/items/64075eb33ab24e7694214f2341a05052/data");
   inline static const QString DEFAULT_DOWNLOAD_NAME = QStringLiteral("Default");
 

--- a/Shared/configurations/ConfigurationListModel.cpp
+++ b/Shared/configurations/ConfigurationListModel.cpp
@@ -206,8 +206,12 @@ void ConfigurationListModel::download(const QString& configurationName)
 {
   for (qsizetype i = 0; i < m_configurations.count(); i++)
   {
-    if (m_configurations[i].name() == configurationName)
+    const Configuration& cfg = m_configurations.at(i);
+    if (cfg.name() == configurationName)
     {
+      if (cfg.downloading())
+        return;
+
       m_configurations[i].download();
       const auto idx = createIndex(i, 0);
       emit dataChanged(idx, idx);

--- a/Shared/configurations/ConfigurationListModel.cpp
+++ b/Shared/configurations/ConfigurationListModel.cpp
@@ -51,6 +51,18 @@ void ConfigurationListModel::cancel(int index)
   emit dataChanged(idx, idx);
 }
 
+void ConfigurationListModel::cancel(const QString& configurationName)
+{
+  for (Configuration& c : m_configurations)
+  {
+    if (c.name() != configurationName)
+      continue;
+
+    c.cancelDownload();
+    return;
+  }
+}
+
 Configuration ConfigurationListModel::at(int index) const
 {
   if (index < 0 || index >= m_configurations.size())

--- a/Shared/configurations/ConfigurationListModel.h
+++ b/Shared/configurations/ConfigurationListModel.h
@@ -66,6 +66,7 @@ public:
   bool add(const QString& name, const QString& url, bool selected, bool loaded, int percentDownloaded);
   void select(int index);
   void cancel(int index);
+  void cancel(const QString& configurationName);
   bool remove(const QString& configurationName);
   void download(const QString& configurationName);
   bool clear();

--- a/Shared/qml/Options.qml
+++ b/Shared/qml/Options.qml
@@ -488,10 +488,19 @@ Rectangle {
                                 anchors.fill: parent
                                 onClicked: {
                                     configurationController.cancel(index);
+                                    if (timerDebounce.running)
+                                        imageDownload.visible = true;
                                 }
                             }
                         }
 
+                        Timer {
+                            id: timerDebounce
+                            interval: 1000
+                            running: false
+                            repeat: false
+                            onTriggered: imageDownload.visible = true;
+                        }
                         Image {
                             id: imageDownload
                             source: "qrc:/Resources/icons/xhdpi/ic_menu_sendmap_dark_d.png"
@@ -505,7 +514,9 @@ Rectangle {
                             MouseArea {
                                 anchors.fill: parent
                                 onClicked: {
+                                    imageDownload.visible = false;
                                     configurationController.download(index);
+                                    timerDebounce.start();
                                 }
                             }
                             rotation: 180

--- a/Shared/qml/Options.qml
+++ b/Shared/qml/Options.qml
@@ -494,12 +494,16 @@ Rectangle {
                             }
                         }
 
+                        property bool downloadOnCooldown: false
                         Timer {
                             id: timerDebounce
-                            interval: 1000
+                            interval: 500
                             running: false
                             repeat: false
-                            onTriggered: imageDownload.visible = true;
+                            onTriggered: {
+                                downloadOnCooldown = false;
+                                imageDownload.visible = true;
+                            }
                         }
                         Image {
                             id: imageDownload
@@ -514,6 +518,10 @@ Rectangle {
                             MouseArea {
                                 anchors.fill: parent
                                 onClicked: {
+                                    if (downloadOnCooldown)
+                                        return;
+
+                                    downloadOnCooldown = true;
                                     imageDownload.visible = false;
                                     configurationController.download(index);
                                     timerDebounce.start();

--- a/Shared/qml/Options.qml
+++ b/Shared/qml/Options.qml
@@ -422,6 +422,7 @@ Rectangle {
                         color: Material.backgroundColor
                         height: 40 * scaleFactor
                         width: parent.width
+                        property bool downloadOnCooldown: false
 
                         ProgressBar {
                             id: progressBarPercentComplete
@@ -492,7 +493,6 @@ Rectangle {
                             }
                         }
 
-                        property bool downloadOnCooldown: false
                         Timer {
                             id: timerDebounce
                             interval: 500
@@ -503,6 +503,7 @@ Rectangle {
                                 imageDownload.visible = true;
                             }
                         }
+
                         Image {
                             id: imageDownload
                             source: "qrc:/Resources/icons/xhdpi/ic_menu_sendmap_dark_d.png"
@@ -611,6 +612,7 @@ Rectangle {
                     id: labelPrompt
                     anchors {
                         top: restartPromptArea.top
+                        horizontalCenter: parent.horizontalCenter
                     }
                     wrapMode: "WordWrap"
                     font {

--- a/Shared/qml/Options.qml
+++ b/Shared/qml/Options.qml
@@ -69,7 +69,7 @@ Rectangle {
         width: parent.width
         anchors {
             top: bar.bottom
-            bottom: buttonDismiss.top
+            bottom: layoutButtonRow.top
         }
 
         currentIndex: bar.currentIndex
@@ -411,7 +411,7 @@ Rectangle {
                 anchors {
                     fill: parent
                     margins: 10 * scaleFactor
-                    bottomMargin: 10 * scaleFactor + buttonCloseApp.height
+                    bottomMargin: 10 * scaleFactor + restartPromptArea.height
                 }
                 clip: true
 
@@ -463,14 +463,12 @@ Rectangle {
                         }
 
                         Label {
-                            id: labelRequiresRestart
                             anchors {
                                 left: labelName.right
                                 verticalCenter: parent.verticalCenter
                                 margins: 2
                             }
                             text: "*"
-                            color: "yellow"
                             font.italic: true
                             visible: model.RequiresRestart
                         }
@@ -552,22 +550,11 @@ Rectangle {
                         }
                     }
                 }
-                Label {
-                    text: "Changing a configuration will require restarting the application"
-                    id: labelRequiresRestart
-                    width: parent.width
-                    wrapMode: "WordWrap"
-                    font {
-                        family: DsaStyles.fontFamily
-                        pixelSize: DsaStyles.titleFontPixelSize * 0.75
-                        italic: true
-                    }
-                }
 
                 ListView {
                     id: configurationList
                     anchors {
-                        top: labelRequiresRestart.bottom
+                        top: parent.top
                         right: parent.right
                         left: parent.left
                         bottom: parent.bottom
@@ -609,32 +596,54 @@ Rectangle {
                 }
             }
 
-            Button {
-                id: buttonCloseApp
+            Rectangle {
+                id: restartPromptArea
                 anchors {
-                    bottom: parent.bottom
-                    horizontalCenter: parent.horizontalCenter
-                    margins: 5
+                    top: configurationsFlickable.bottom
+                    margins: configurationController.requiresRestart ? 5 : 0
                 }
-                onClicked: {
-                    showCloseDialog("Are you sure you want to close?");
-                }
-
-                text: "Close App"
+                color: "transparent"
+                width: parent.width
+                height: configurationController.requiresRestart ? labelPrompt.height : 0
                 visible: configurationController.requiresRestart
+
+                Label {
+                    id: labelPrompt
+                    anchors {
+                        top: restartPromptArea.top
+                    }
+                    wrapMode: "WordWrap"
+                    font {
+                        family: DsaStyles.fontFamily
+                        pixelSize: DsaStyles.titleFontPixelSize * 0.75 * scaleFactor
+                        italic: true
+                    }
+
+                    text: "*Close and restart the app\nto load new configuration"
+                }
             }
         }
     }
-    Button {
-        id: buttonDismiss
+    RowLayout {
+        id: layoutButtonRow
         anchors {
             horizontalCenter: parent.horizontalCenter
             bottom: parent.bottom
             margins: 10 * scaleFactor
         }
-        text: "Dismiss"
-        onClicked: {
-            optionsRoot.visible = false;
+
+        Button {
+            text: "Close App"
+            visible: configurationController.requiresRestart
+            onClicked: {
+                showCloseDialog("Are you sure you want to close?");
+            }
+        }
+        Button {
+            text: "Dismiss"
+            onClicked: {
+                optionsRoot.visible = false;
+            }
         }
     }
 

--- a/Vehicle/qml/main.qml
+++ b/Vehicle/qml/main.qml
@@ -33,12 +33,13 @@ Vehicle {
     property real hudOpacity: 0.9
     property real hudRadius: 3 * scaleFactor
     property real hudMargins: 5 * scaleFactor
+    property bool configurationsChanged: false
+    property bool promptedForDefaultDownload: false
 
     signal clearDialogAccepted();
     signal closeDialogAccepted();
     signal inputDialogAccepted(var input, var index);
     signal markupLayerReceived(var path, var overlayVisible);
-    property bool configurationsChanged: false
 
     LocationController {
         id: locationController

--- a/Vehicle/qml/main.qml
+++ b/Vehicle/qml/main.qml
@@ -637,7 +637,6 @@ Vehicle {
         onRejected: showConfigurations(false);
     }
 
-    property bool promptedForDefaultDownload: false
     function showConfigurations(downloadDefaultData) {
         // prevents multiple 'Yes' taps.
         // this dialog should only be shown on the initial startup.

--- a/Vehicle/qml/main.qml
+++ b/Vehicle/qml/main.qml
@@ -631,7 +631,7 @@ Vehicle {
 
     DsaYesNoDialog {
         id: configurationDownloadDialog
-        informativeText: "Download the default configuration data from Esri (~450mb)?"
+        informativeText: DsaResources.DefaultConfigurationDownloadPrompt
         onAccepted: showConfigurations(true);
         onRejected: showConfigurations(false);
     }

--- a/Vehicle/qml/main.qml
+++ b/Vehicle/qml/main.qml
@@ -635,7 +635,15 @@ Vehicle {
         onAccepted: showConfigurations(true);
         onRejected: showConfigurations(false);
     }
+
+    property bool promptedForDefaultDownload: false
     function showConfigurations(downloadDefaultData) {
+        // prevents multiple 'Yes' taps.
+        // this dialog should only be shown on the initial startup.
+        if (promptedForDefaultDownload)
+            return;
+
+        promptedForDefaultDownload = true;
         if (downloadDefaultData)
             configurationController.downloadDefaultData();
 


### PR DESCRIPTION
- Consolidate the message displayed for the UI as a single string resource
- Prevent the UI from allowing multiple inadvertent downloads for the same configuration
- Update the itemID for the default configuration data download
- Remove the action to create a default configuration file if one is not found in the configuration directory
- Remove the exception that existed for the Esri default download not needing a config file
- Clean up the UI for the configurations list panel