### PR TITLE
turn off highlightFollowsCurrentItem for all platforms

### DIFF
--- a/Shared/qml/MessageFeeds.qml
+++ b/Shared/qml/MessageFeeds.qml
@@ -73,7 +73,7 @@ DsaPanel {
             id: messageFeedsList
             clip: true
             model: toolController.messageFeeds
-            highlightFollowsCurrentItem: isMobile
+            highlightFollowsCurrentItem: false
             highlightMoveVelocity: 10000
             highlight: Rectangle {
                 radius: 5 * scaleFactor


### PR DESCRIPTION
minor tweak to prevent item from being selected on startup in the MessageFeeds list for mobile platform